### PR TITLE
feat: Refactor options and function signatures for improved usability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,7 +219,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "comrak"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "comrak 0.41.0",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ crate-type = ["cdylib"]
 
 [package]
 name = "comrak"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -26,46 +26,45 @@ Fast Markdown to HTML parser in Rust, shipped for Python via PyO3.
 
 ## API
 
-### `render_markdown`
+### `markdown_to_html`
 
 Render Markdown to HTML:
 
 ```python
-from comrak import ExtensionOptions, render_markdown
+from comrak import ExtensionOptions, markdown_to_html
 extension_options = ExtensionOptions()
-render_markdown("foo :smile:", extension_options)
+markdown_to_html("foo :smile:", extension_options)
 # '<p>foo :smile:</p>\n'
 
 extension_options.shortcodes = True
-render_markdown("foo :smile:", extension_options)
+markdown_to_html("foo :smile:", extension_options)
 # '<p>foo 😄</p>\n'
 ```
 
-### `render_markdown_to_commonmark`
+### `markdown_to_commonmark`
 
 Render Markdown to CommonMark:
 
 ```python
-from comrak import RenderOptions, ListStyleType, render_markdown_to_commonmark
+from comrak import RenderOptions, ListStyleType, markdown_to_commonmark
 
 render_options = RenderOptions()
-render_markdown_to_commonmark("- one\n- two\n- three", render_options=render_options)
+markdown_to_commonmark("- one\n- two\n- three", render_options=render_options)
 
 # '- one\n- two\n- three\n' – default is Dash
 render_options.list_style = ListStyleType.Plus
-render_markdown_to_commonmark("- one\n- two\n- three", render_options=render_options)
+markdown_to_commonmark("- one\n- two\n- three", render_options=render_options)
 # '+ one\n+ two\n+ three\n'
 ```
 
-### `parse_markdown`
+### `parse_document`
 
 Parse Markdown into an abstract syntax tree (AST):
 
 ```python
-from comrak import ExtensionOptions, Document, Text, Paragraph, parse_markdown
+from comrak import ExtensionOptions, Document, Text, Paragraph, parse_document
 
-extension_options = ExtensionOptions()
-extension_options.front_matter_delimiter = "---"
+extension_options = ExtensionOptions(front_matter_delimiter = "---")
 
 md_content = """---
 This is a text in FrontMatter
@@ -74,7 +73,7 @@ This is a text in FrontMatter
 Hello, Markdown!
 """
 
-x = parse_markdown(md_content, extension_options)
+x = parse_document(md_content, extension_options)
 assert isinstance(x.node_value, Document)
 assert not hasattr(x.node_value, "value")
 assert len(x.children) == 2
@@ -92,7 +91,7 @@ assert x.children[1].children[0].node_value.value == "Hello, Markdown!"
 
 ### Options
 
-All options are exposed in a simple manner and can be used with both `render_markdown`, `render_markdown_to_commonmark`, and `parse_markdown`.
+All options are exposed in a simple manner and can be used with `markdown_to_html`, `markdown_to_commonmark`, and `parse_document`.
 
 Refer to the [Comrak docs](https://docs.rs/comrak/latest/comrak/struct.Options.html) for all available options.
 

--- a/comrak.pyi
+++ b/comrak.pyi
@@ -35,10 +35,12 @@ class ListStyleType(Enum):
 class NodeCode:
     num_backticks: int
     literal: str
+    def __init__(self, num_backticks: int, literal: str) -> None: ...
 
 class NodeHtmlBlock:
     block_type: int
     literal: str
+    def __init__(self, block_type: int, literal: str) -> None: ...
 
 class NodeList:
     list_type: ListType
@@ -49,11 +51,23 @@ class NodeList:
     bullet_char: int
     tight: bool
     is_task_list: bool
+    def __init__(
+        self,
+        list_type: ListType,
+        marker_offset: int,
+        padding: int,
+        start: int,
+        delimiter: ListDelimType,
+        bullet_char: int,
+        tight: bool,
+        is_task_list: bool,
+    ) -> None: ...
 
 class NodeDescriptionItem:
     marker_offset: int
     padding: int
     tight: bool
+    def __init__(self, marker_offset: int, padding: int, tight: bool) -> None: ...
 
 class NodeCodeBlock:
     fenced: bool
@@ -62,45 +76,69 @@ class NodeCodeBlock:
     fence_offset: int
     info: str
     literal: str
+    def __init__(
+        self,
+        fenced: bool,
+        fence_char: int,
+        fence_length: int,
+        fence_offset: int,
+        info: str,
+        literal: str,
+    ) -> None: ...
 
 class NodeHeading:
     level: int
     setext: bool
+    def __init__(self, level: int, setext: bool) -> None: ...
 
 class NodeTable:
     alignments: list[TableAlignment]
     num_columns: int
     num_rows: int
     num_nonempty_cells: int
+    def __init__(
+        self,
+        alignments: list[TableAlignment] | None,
+        num_columns: int,
+        num_rows: int,
+        num_nonempty_cells: int,
+    ) -> None: ...
 
 class NodeLink:
     url: str
     title: str
+    def __init__(self, url: str, title: str) -> None: ...
 
 class NodeFootnoteDefinition:
     name: str
     total_references: int
+    def __init__(self, name: str, total_references: int) -> None: ...
 
 class NodeFootnoteReference:
     name: str
     ref_num: int
     ix: int
+    def __init__(self, name: str, ref_num: int, ix: int) -> None: ...
 
 class NodeWikiLink:
     url: str
+    def __init__(self, url: str) -> None: ...
 
 class NodeShortCode:
     code: str
     emoji: str
+    def __init__(self, code: str, emoji: str) -> None: ...
 
 class NodeMath:
     dollar_math: bool
     display_math: bool
     literal: str
+    def __init__(self, dollar_math: bool, display_math: bool, literal: str) -> None: ...
 
 class NodeMultilineBlockQuote:
     fence_length: int
     fence_offset: int
+    def __init__(self, fence_length: int, fence_offset: int) -> None: ...
 
 class NodeAlert:
     alert_type: AlertType
@@ -108,150 +146,181 @@ class NodeAlert:
     multiline: bool
     fence_length: int
     fence_offset: int
+    def __init__(
+        self,
+        alert_type: AlertType,
+        title: Optional[str],
+        multiline: bool,
+        fence_length: int,
+        fence_offset: int,
+    ) -> None: ...
 
 class Document(NodeValue[None]):
-    pass
+    def __init__(self) -> None: ...
 
 class FrontMatter(NodeValue[str]):
     value: str
+    def __init__(self, value: str) -> None: ...
 
 class BlockQuote(NodeValue[None]):
-    pass
+    def __init__(self) -> None: ...
 
 class List(NodeValue[NodeList]):
     value: NodeList
+    def __init__(self, value: NodeList) -> None: ...
 
 class Item(NodeValue[NodeList]):
     value: NodeList
+    def __init__(self, value: NodeList) -> None: ...
 
 class DescriptionList(NodeValue[None]):
-    pass
+    def __init__(self) -> None: ...
 
 class DescriptionItem(NodeValue[NodeDescriptionItem]):
     value: NodeDescriptionItem
+    def __init__(self, value: NodeDescriptionItem) -> None: ...
 
 class DescriptionTerm(NodeValue[None]):
-    pass
+    def __init__(self) -> None: ...
 
 class DescriptionDetails(NodeValue[None]):
-    pass
+    def __init__(self) -> None: ...
 
 class CodeBlock(NodeValue[NodeCodeBlock]):
     value: NodeCodeBlock
+    def __init__(self, value: NodeCodeBlock) -> None: ...
 
 class HtmlBlock(NodeValue[NodeHtmlBlock]):
     value: NodeHtmlBlock
+    def __init__(self, value: NodeHtmlBlock) -> None: ...
 
 class Paragraph(NodeValue[None]):
-    pass
+    def __init__(self) -> None: ...
 
 class Heading(NodeValue[NodeHeading]):
     value: NodeHeading
+    def __init__(self, value: NodeHeading) -> None: ...
 
 class ThematicBreak(NodeValue[None]):
-    pass
+    def __init__(self) -> None: ...
 
 class FootnoteDefinition(NodeValue[NodeFootnoteDefinition]):
     value: NodeFootnoteDefinition
+    def __init__(self, value: NodeFootnoteDefinition) -> None: ...
 
 class Table(NodeValue[NodeTable]):
     value: NodeTable
+    def __init__(self, value: NodeTable) -> None: ...
 
 class TableRow(NodeValue[bool]):
     value: bool
+    def __init__(self, value: bool) -> None: ...
 
 class TableCell(NodeValue[None]):
-    pass
+    def __init__(self) -> None: ...
 
 class Text(NodeValue[str]):
     value: str
+    def __init__(self, value: str) -> None: ...
 
 class TaskItem(NodeValue[Optional[str]]):
     value: Optional[str]
+    def __init__(self, value: Optional[str]) -> None: ...
 
 class SoftBreak(NodeValue[None]):
-    pass
+    def __init__(self) -> None: ...
 
 class LineBreak(NodeValue[None]):
-    pass
+    def __init__(self) -> None: ...
 
 class Code(NodeValue[NodeCode]):
     value: NodeCode
+    def __init__(self, value: NodeCode) -> None: ...
 
 class HtmlInline(NodeValue[str]):
     value: str
+    def __init__(self, value: str) -> None: ...
 
 class Raw(NodeValue[str]):
     value: str
+    def __init__(self, value: str) -> None: ...
 
 class Emph(NodeValue[None]):
-    pass
+    def __init__(self) -> None: ...
 
 class Strong(NodeValue[None]):
-    pass
+    def __init__(self) -> None: ...
 
 class Strikethrough(NodeValue[None]):
-    pass
+    def __init__(self) -> None: ...
 
 class Superscript(NodeValue[None]):
-    pass
+    def __init__(self) -> None: ...
 
 class Link(NodeValue[NodeLink]):
     value: NodeLink
+    def __init__(self, value: NodeLink) -> None: ...
 
 class Image(NodeValue[NodeLink]):
     value: NodeLink
+    def __init__(self, value: NodeLink) -> None: ...
 
 class FootnoteReference(NodeValue[NodeFootnoteReference]):
     value: NodeFootnoteReference
+    def __init__(self, value: NodeFootnoteReference) -> None: ...
 
 class ShortCode(NodeValue[NodeShortCode]):
     value: NodeShortCode
+    def __init__(self, value: NodeShortCode) -> None: ...
 
 class Math(NodeValue[NodeMath]):
     value: NodeMath
+    def __init__(self, value: NodeMath) -> None: ...
 
 class MultilineBlockQuote(NodeValue[NodeMultilineBlockQuote]):
     value: NodeMultilineBlockQuote
+    def __init__(self, value: NodeMultilineBlockQuote) -> None: ...
 
 class Escaped(NodeValue[None]):
-    pass
+    def __init__(self) -> None: ...
 
 class WikiLink(NodeValue[NodeWikiLink]):
     value: NodeWikiLink
+    def __init__(self, value: NodeWikiLink) -> None: ...
 
 class Underline(NodeValue[None]):
-    pass
+    def __init__(self) -> None: ...
 
 class Subscript(NodeValue[None]):
-    pass
+    def __init__(self) -> None: ...
 
 class SpoileredText(NodeValue[None]):
-    pass
+    def __init__(self) -> None: ...
 
 class EscapedTag(NodeValue[str]):
     value: str
+    def __init__(self, value: str) -> None: ...
 
 class Alert(NodeValue[NodeAlert]):
     value: NodeAlert
+    def __init__(self, value: NodeAlert) -> None: ...
 
 class LineColumn:
     line: int
     column: int
+    def __init__(self, line: int, column: int) -> None: ...
 
 class Sourcepos:
     start: LineColumn
     end: LineColumn
+    def __init__(self, start: LineColumn, end: LineColumn) -> None: ...
 
 class AstNode:
     node_value: NodeValue
     sourcepos: Sourcepos
     children: list[AstNode]
     def __init__(
-        self,
-        node_value: NodeValue,
-        sourcepos: Sourcepos,
-        children: list[AstNode],
+        self, node_value: NodeValue, sourcepos: Sourcepos, children: list[AstNode]
     ) -> None: ...
 
 class ExtensionOptions:
@@ -277,14 +346,44 @@ class ExtensionOptions:
     spoiler: bool
     greentext: bool
     cjk_friendly_emphasis: bool
-    def __init__(self) -> None: ...
+    def __init__(
+        self,
+        strikethrough: bool = False,
+        tagfilter: bool = False,
+        table: bool = False,
+        autolink: bool = False,
+        tasklist: bool = False,
+        superscript: bool = False,
+        header_ids: Optional[str] = None,
+        footnotes: bool = False,
+        description_lists: bool = False,
+        front_matter_delimiter: Optional[str] = None,
+        multiline_block_quotes: bool = False,
+        alerts: bool = False,
+        math_dollars: bool = False,
+        math_code: bool = False,
+        shortcodes: bool = False,
+        wikilinks_title_after_pipe: bool = False,
+        wikilinks_title_before_pipe: bool = False,
+        underline: bool = False,
+        subscript: bool = False,
+        spoiler: bool = False,
+        greentext: bool = False,
+        cjk_friendly_emphasis: bool = False,
+    ) -> None: ...
 
 class ParseOptions:
     smart: bool
     default_info_string: Optional[str]
     relaxed_tasklist_matching: bool
     relaxed_autolinks: bool
-    def __init__(self) -> None: ...
+    def __init__(
+        self,
+        smart: bool = False,
+        default_info_string: Optional[str] = None,
+        relaxed_tasklist_matching: bool = False,
+        relaxed_autolinks: bool = False,
+    ) -> None: ...
 
 class RenderOptions:
     hardbreaks: bool
@@ -304,21 +403,40 @@ class RenderOptions:
     tasklist_classes: bool
     ol_width: int
     experimental_minimize_commonmark: bool
-    def __init__(self) -> None: ...
+    def __init__(
+        self,
+        hardbreaks: bool = False,
+        github_pre_lang: bool = False,
+        full_info_string: bool = False,
+        width: int = 0,
+        unsafe_: bool = False,
+        escape: bool = False,
+        list_style: ListStyleType = ListStyleType.Dash,
+        sourcepos: bool = False,
+        escaped_char_spans: bool = False,
+        ignore_setext: bool = False,
+        ignore_empty_links: bool = False,
+        gfm_quirks: bool = False,
+        prefer_fenced: bool = False,
+        figure_with_caption: bool = False,
+        tasklist_classes: bool = False,
+        ol_width: int = 0,
+        experimental_minimize_commonmark: bool = False,
+    ) -> None: ...
 
-def render_markdown(
+def markdown_to_html(
     text: str,
     extension_options: Optional[ExtensionOptions] = None,
     parse_options: Optional[ParseOptions] = None,
     render_options: Optional[RenderOptions] = None,
 ) -> str: ...
-def render_markdown_to_commonmark(
+def markdown_to_commonmark(
     text: str,
     extension_options: Optional[ExtensionOptions] = None,
     parse_options: Optional[ParseOptions] = None,
     render_options: Optional[RenderOptions] = None,
 ) -> str: ...
-def parse_markdown(
+def parse_document(
     text: str,
     extension_options: Optional[ExtensionOptions] = None,
     parse_options: Optional[ParseOptions] = None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ keywords = [
 ]
 readme = "README.md"
 requires-python = ">=3.9"
-version = "0.1.0"
+version = "0.1.1"
 
 [project.license]
 file = "LICENSE"

--- a/src/astnode.rs
+++ b/src/astnode.rs
@@ -1,8 +1,7 @@
-use pyo3::{prelude::*, pyclass};
 use comrak_lib::nodes::*;
+use pyo3::{prelude::*, pyclass};
 
-
-#[pyclass(name = "LineColumn", get_all)]
+#[pyclass(name = "LineColumn", get_all, set_all)]
 #[derive(Clone)]
 pub struct PyLineColumn {
     pub line: usize,
@@ -18,7 +17,15 @@ impl From<&LineColumn> for PyLineColumn {
     }
 }
 
-#[pyclass(name = "Sourcepos", get_all)]
+#[pymethods]
+impl PyLineColumn {
+    #[new]
+    pub fn new(line: usize, column: usize) -> Self {
+        Self { line, column }
+    }
+}
+
+#[pyclass(name = "Sourcepos", get_all, set_all)]
 #[derive(Clone)]
 pub struct PySourcepos {
     pub start: PyLineColumn,
@@ -34,7 +41,15 @@ impl From<&Sourcepos> for PySourcepos {
     }
 }
 
-#[pyclass(name = "NodeCode", get_all)]
+#[pymethods]
+impl PySourcepos {
+    #[new]
+    pub fn new(start: PyLineColumn, end: PyLineColumn) -> Self {
+        Self { start, end }
+    }
+}
+
+#[pyclass(name = "NodeCode", get_all, set_all)]
 #[derive(Clone)]
 pub struct PyNodeCode {
     pub num_backticks: usize,
@@ -50,7 +65,18 @@ impl From<&NodeCode> for PyNodeCode {
     }
 }
 
-#[pyclass(name = "NodeHtmlBlock", get_all)]
+#[pymethods]
+impl PyNodeCode {
+    #[new]
+    pub fn new(num_backticks: usize, literal: String) -> Self {
+        Self {
+            num_backticks,
+            literal,
+        }
+    }
+}
+
+#[pyclass(name = "NodeHtmlBlock", get_all, set_all)]
 #[derive(Clone)]
 pub struct PyNodeHtmlBlock {
     pub block_type: u8,
@@ -66,8 +92,19 @@ impl From<&NodeHtmlBlock> for PyNodeHtmlBlock {
     }
 }
 
-#[pyclass(name = "ListDelimType")]
-#[derive(Clone, Copy)]
+#[pymethods]
+impl PyNodeHtmlBlock {
+    #[new]
+    pub fn new(block_type: u8, literal: String) -> Self {
+        Self {
+            block_type,
+            literal,
+        }
+    }
+}
+
+#[pyclass(name = "ListDelimType", eq, eq_int)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub enum PyListDelimType {
     Period,
     Paren,
@@ -82,8 +119,8 @@ impl From<ListDelimType> for PyListDelimType {
     }
 }
 
-#[pyclass(name = "ListType")]
-#[derive(Clone, Copy)]
+#[pyclass(name = "ListType", eq, eq_int)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub enum PyListType {
     Bullet,
     Ordered,
@@ -98,10 +135,10 @@ impl From<ListType> for PyListType {
     }
 }
 
-#[pyclass(name = "TableAlignment")]
-#[derive(Clone, Copy)]
+#[pyclass(name = "TableAlignment", eq, eq_int)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub enum PyTableAlignment {
-    #[pyo3(name = "None_")]  // named 'None_' because 'None' is reserved in Python
+    #[pyo3(name = "None_")] // named 'None_' because 'None' is reserved in Python
     None,
     Left,
     Center,
@@ -119,7 +156,7 @@ impl From<TableAlignment> for PyTableAlignment {
     }
 }
 
-#[pyclass(name = "NodeList", get_all)]
+#[pyclass(name = "NodeList", get_all, set_all)]
 #[derive(Clone, Copy)]
 pub struct PyNodeList {
     pub list_type: PyListType,
@@ -147,8 +184,33 @@ impl From<&NodeList> for PyNodeList {
     }
 }
 
+#[pymethods]
+impl PyNodeList {
+    #[new]
+    pub fn new(
+        list_type: PyListType,
+        marker_offset: usize,
+        padding: usize,
+        start: usize,
+        delimiter: PyListDelimType,
+        bullet_char: u8,
+        tight: bool,
+        is_task_list: bool,
+    ) -> Self {
+        Self {
+            list_type,
+            marker_offset,
+            padding,
+            start,
+            delimiter,
+            bullet_char,
+            tight,
+            is_task_list,
+        }
+    }
+}
 
-#[pyclass(name = "NodeDescriptionItem", get_all)]
+#[pyclass(name = "NodeDescriptionItem", get_all, set_all)]
 #[derive(Clone, Copy)]
 pub struct PyNodeDescriptionItem {
     pub marker_offset: usize,
@@ -166,7 +228,19 @@ impl From<&NodeDescriptionItem> for PyNodeDescriptionItem {
     }
 }
 
-#[pyclass(name = "NodeCodeBlock", get_all)]
+#[pymethods]
+impl PyNodeDescriptionItem {
+    #[new]
+    pub fn new(marker_offset: usize, padding: usize, tight: bool) -> Self {
+        Self {
+            marker_offset,
+            padding,
+            tight,
+        }
+    }
+}
+
+#[pyclass(name = "NodeCodeBlock", get_all, set_all)]
 #[derive(Clone)]
 pub struct PyNodeCodeBlock {
     pub fenced: bool,
@@ -190,7 +264,29 @@ impl From<&NodeCodeBlock> for PyNodeCodeBlock {
     }
 }
 
-#[pyclass(name = "NodeHeading", get_all)]
+#[pymethods]
+impl PyNodeCodeBlock {
+    #[new]
+    pub fn new(
+        fenced: bool,
+        fence_char: u8,
+        fence_length: usize,
+        fence_offset: usize,
+        info: String,
+        literal: String,
+    ) -> Self {
+        Self {
+            fenced,
+            fence_char,
+            fence_length,
+            fence_offset,
+            info,
+            literal,
+        }
+    }
+}
+
+#[pyclass(name = "NodeHeading", get_all, set_all)]
 #[derive(Clone, Copy)]
 pub struct PyNodeHeading {
     pub level: u8,
@@ -206,7 +302,15 @@ impl From<&NodeHeading> for PyNodeHeading {
     }
 }
 
-#[pyclass(name = "NodeTable", get_all)]
+#[pymethods]
+impl PyNodeHeading {
+    #[new]
+    pub fn new(level: u8, setext: bool) -> Self {
+        Self { level, setext }
+    }
+}
+
+#[pyclass(name = "NodeTable", get_all, set_all)]
 #[derive(Clone)]
 pub struct PyNodeTable {
     pub alignments: Vec<PyTableAlignment>,
@@ -218,7 +322,11 @@ pub struct PyNodeTable {
 impl From<&NodeTable> for PyNodeTable {
     fn from(table: &NodeTable) -> Self {
         Self {
-            alignments: table.alignments.iter().map(|a| PyTableAlignment::from(*a)).collect(),
+            alignments: table
+                .alignments
+                .iter()
+                .map(|a| PyTableAlignment::from(*a))
+                .collect(),
             num_columns: table.num_columns,
             num_rows: table.num_rows,
             num_nonempty_cells: table.num_nonempty_cells,
@@ -226,9 +334,25 @@ impl From<&NodeTable> for PyNodeTable {
     }
 }
 
+#[pymethods]
+impl PyNodeTable {
+    #[new]
+    pub fn new(
+        alignments: Vec<PyTableAlignment>,
+        num_columns: usize,
+        num_rows: usize,
+        num_nonempty_cells: usize,
+    ) -> Self {
+        Self {
+            alignments,
+            num_columns,
+            num_rows,
+            num_nonempty_cells,
+        }
+    }
+}
 
-
-#[pyclass(name = "NodeLink", get_all)]
+#[pyclass(name = "NodeLink", get_all, set_all)]
 #[derive(Clone)]
 pub struct PyNodeLink {
     pub url: String,
@@ -244,8 +368,15 @@ impl From<&NodeLink> for PyNodeLink {
     }
 }
 
+#[pymethods]
+impl PyNodeLink {
+    #[new]
+    pub fn new(url: String, title: String) -> Self {
+        Self { url, title }
+    }
+}
 
-#[pyclass(name = "NodeFootnoteDefinition", get_all)]
+#[pyclass(name = "NodeFootnoteDefinition", get_all, set_all)]
 #[derive(Clone)]
 pub struct PyNodeFootnoteDefinition {
     pub name: String,
@@ -261,7 +392,18 @@ impl From<&NodeFootnoteDefinition> for PyNodeFootnoteDefinition {
     }
 }
 
-#[pyclass(name = "NodeFootnoteReference", get_all)]
+#[pymethods]
+impl PyNodeFootnoteDefinition {
+    #[new]
+    pub fn new(name: String, total_references: u32) -> Self {
+        Self {
+            name,
+            total_references,
+        }
+    }
+}
+
+#[pyclass(name = "NodeFootnoteReference", get_all, set_all)]
 #[derive(Clone)]
 pub struct PyNodeFootnoteReference {
     pub name: String,
@@ -279,7 +421,15 @@ impl From<&NodeFootnoteReference> for PyNodeFootnoteReference {
     }
 }
 
-#[pyclass(name = "NodeWikiLink", get_all)]
+#[pymethods]
+impl PyNodeFootnoteReference {
+    #[new]
+    pub fn new(name: String, ref_num: u32, ix: u32) -> Self {
+        Self { name, ref_num, ix }
+    }
+}
+
+#[pyclass(name = "NodeWikiLink", get_all, set_all)]
 #[derive(Clone)]
 pub struct PyNodeWikiLink {
     pub url: String,
@@ -287,13 +437,19 @@ pub struct PyNodeWikiLink {
 
 impl From<&NodeWikiLink> for PyNodeWikiLink {
     fn from(w: &NodeWikiLink) -> Self {
-        Self {
-            url: w.url.clone(),
-        }
+        Self { url: w.url.clone() }
     }
 }
 
-#[pyclass(name = "NodeShortCode", get_all)]
+#[pymethods]
+impl PyNodeWikiLink {
+    #[new]
+    pub fn new(url: String) -> Self {
+        Self { url }
+    }
+}
+
+#[pyclass(name = "NodeShortCode", get_all, set_all)]
 #[derive(Clone)]
 pub struct PyNodeShortCode {
     pub code: String,
@@ -309,7 +465,15 @@ impl From<&NodeShortCode> for PyNodeShortCode {
     }
 }
 
-#[pyclass(name = "NodeMath", get_all)]
+#[pymethods]
+impl PyNodeShortCode {
+    #[new]
+    pub fn new(code: String, emoji: String) -> Self {
+        Self { code, emoji }
+    }
+}
+
+#[pyclass(name = "NodeMath", get_all, set_all)]
 #[derive(Clone)]
 pub struct PyNodeMath {
     pub dollar_math: bool,
@@ -327,7 +491,19 @@ impl From<&NodeMath> for PyNodeMath {
     }
 }
 
-#[pyclass(name = "NodeMultilineBlockQuote", get_all)]
+#[pymethods]
+impl PyNodeMath {
+    #[new]
+    pub fn new(dollar_math: bool, display_math: bool, literal: String) -> Self {
+        Self {
+            dollar_math,
+            display_math,
+            literal,
+        }
+    }
+}
+
+#[pyclass(name = "NodeMultilineBlockQuote", get_all, set_all)]
 #[derive(Clone, Copy)]
 pub struct PyNodeMultilineBlockQuote {
     pub fence_length: usize,
@@ -343,8 +519,19 @@ impl From<&NodeMultilineBlockQuote> for PyNodeMultilineBlockQuote {
     }
 }
 
-#[pyclass(name = "AlertType")]
-#[derive(Clone, Copy)]
+#[pymethods]
+impl PyNodeMultilineBlockQuote {
+    #[new]
+    pub fn new(fence_length: usize, fence_offset: usize) -> Self {
+        Self {
+            fence_length,
+            fence_offset,
+        }
+    }
+}
+
+#[pyclass(name = "AlertType", eq, eq_int)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub enum PyAlertType {
     Note,
     Tip,
@@ -365,7 +552,7 @@ impl From<AlertType> for PyAlertType {
     }
 }
 
-#[pyclass(name = "NodeAlert", get_all)]
+#[pyclass(name = "NodeAlert", get_all, set_all)]
 #[derive(Clone)]
 pub struct PyNodeAlert {
     pub alert_type: PyAlertType,
@@ -387,258 +574,870 @@ impl From<&NodeAlert> for PyNodeAlert {
     }
 }
 
+#[pymethods]
+impl PyNodeAlert {
+    #[new]
+    pub fn new(
+        alert_type: PyAlertType,
+        title: Option<String>,
+        multiline: bool,
+        fence_length: usize,
+        fence_offset: usize,
+    ) -> Self {
+        Self {
+            alert_type,
+            title,
+            multiline,
+            fence_length,
+            fence_offset,
+        }
+    }
+}
 
 #[pyclass(name = "NodeValue", subclass)]
-pub struct PyNodeValue {
+pub struct PyNodeValue {}
+
+#[pymethods]
+impl PyNodeValue {
+    #[new]
+    pub fn new() -> Self {
+        Self {}
+    }
 }
 
 #[pyclass(name = "Document", extends=PyNodeValue)]
-pub struct PyDocument {
+pub struct PyDocument {}
+
+#[pymethods]
+impl PyDocument {
+    #[new]
+    pub fn new() -> (Self, PyNodeValue) {
+        (Self {}, PyNodeValue::new())
+    }
 }
 
-#[pyclass(name = "FrontMatter", extends=PyNodeValue, get_all)]
+#[pyclass(name = "FrontMatter", extends=PyNodeValue, get_all, set_all)]
 pub struct PyFrontMatter {
     pub value: String,
+}
+
+#[pymethods]
+impl PyFrontMatter {
+    #[new]
+    pub fn new(value: String) -> (Self, PyNodeValue) {
+        (Self { value }, PyNodeValue::new())
+    }
 }
 
 #[pyclass(name = "BlockQuote", extends=PyNodeValue)]
 pub struct PyBlockQuote {}
 
-#[pyclass(name = "List", extends=PyNodeValue, get_all)]
+#[pymethods]
+impl PyBlockQuote {
+    #[new]
+    pub fn new() -> (Self, PyNodeValue) {
+        (Self {}, PyNodeValue::new())
+    }
+}
+
+#[pyclass(name = "List", extends=PyNodeValue, get_all, set_all)]
 pub struct PyList {
     pub value: PyNodeList,
 }
 
-#[pyclass(name = "Item", extends=PyNodeValue, get_all)]
+#[pymethods]
+impl PyList {
+    #[new]
+    pub fn new(value: PyNodeList) -> (Self, PyNodeValue) {
+        (Self { value }, PyNodeValue::new())
+    }
+}
+
+#[pyclass(name = "Item", extends=PyNodeValue, get_all, set_all)]
 pub struct PyItem {
     pub value: PyNodeList,
+}
+
+#[pymethods]
+impl PyItem {
+    #[new]
+    pub fn new(value: PyNodeList) -> (Self, PyNodeValue) {
+        (Self { value }, PyNodeValue::new())
+    }
 }
 
 #[pyclass(name = "DescriptionList", extends=PyNodeValue)]
 pub struct PyDescriptionList {}
 
-#[pyclass(name = "DescriptionItem", extends=PyNodeValue, get_all)]
+#[pymethods]
+impl PyDescriptionList {
+    #[new]
+    pub fn new() -> (Self, PyNodeValue) {
+        (Self {}, PyNodeValue::new())
+    }
+}
+
+#[pyclass(name = "DescriptionItem", extends=PyNodeValue, get_all, set_all)]
 pub struct PyDescriptionItem {
     pub value: PyNodeDescriptionItem,
+}
+
+#[pymethods]
+impl PyDescriptionItem {
+    #[new]
+    pub fn new(value: PyNodeDescriptionItem) -> (Self, PyNodeValue) {
+        (Self { value }, PyNodeValue::new())
+    }
 }
 
 #[pyclass(name = "DescriptionTerm", extends=PyNodeValue)]
 pub struct PyDescriptionTerm {}
 
+#[pymethods]
+impl PyDescriptionTerm {
+    #[new]
+    pub fn new() -> (Self, PyNodeValue) {
+        (Self {}, PyNodeValue::new())
+    }
+}
+
 #[pyclass(name = "DescriptionDetails", extends=PyNodeValue)]
 pub struct PyDescriptionDetails {}
 
-#[pyclass(name = "CodeBlock", extends=PyNodeValue, get_all)]
+#[pymethods]
+impl PyDescriptionDetails {
+    #[new]
+    pub fn new() -> (Self, PyNodeValue) {
+        (Self {}, PyNodeValue::new())
+    }
+}
+
+#[pyclass(name = "CodeBlock", extends=PyNodeValue, get_all, set_all)]
 pub struct PyCodeBlock {
     pub value: PyNodeCodeBlock,
 }
 
-#[pyclass(name = "HtmlBlock", extends=PyNodeValue, get_all)]
+#[pymethods]
+impl PyCodeBlock {
+    #[new]
+    pub fn new(value: PyNodeCodeBlock) -> (Self, PyNodeValue) {
+        (Self { value }, PyNodeValue::new())
+    }
+}
+
+#[pyclass(name = "HtmlBlock", extends=PyNodeValue, get_all, set_all)]
 pub struct PyHtmlBlock {
     pub value: PyNodeHtmlBlock,
+}
+
+#[pymethods]
+impl PyHtmlBlock {
+    #[new]
+    pub fn new(value: PyNodeHtmlBlock) -> (Self, PyNodeValue) {
+        (Self { value }, PyNodeValue::new())
+    }
 }
 
 #[pyclass(name = "Paragraph", extends=PyNodeValue)]
 pub struct PyParagraph {}
 
-#[pyclass(name = "Heading", extends=PyNodeValue, get_all)]
+#[pymethods]
+impl PyParagraph {
+    #[new]
+    pub fn new() -> (Self, PyNodeValue) {
+        (Self {}, PyNodeValue::new())
+    }
+}
+
+#[pyclass(name = "Heading", extends=PyNodeValue, get_all, set_all)]
 pub struct PyHeading {
     pub value: PyNodeHeading,
+}
+
+#[pymethods]
+impl PyHeading {
+    #[new]
+    pub fn new(value: PyNodeHeading) -> (Self, PyNodeValue) {
+        (Self { value }, PyNodeValue::new())
+    }
 }
 
 #[pyclass(name = "ThematicBreak", extends=PyNodeValue)]
 pub struct PyThematicBreak {}
 
-#[pyclass(name = "FootnoteDefinition", extends=PyNodeValue, get_all)]
+#[pymethods]
+impl PyThematicBreak {
+    #[new]
+    pub fn new() -> (Self, PyNodeValue) {
+        (Self {}, PyNodeValue::new())
+    }
+}
+
+#[pyclass(name = "FootnoteDefinition", extends=PyNodeValue, get_all, set_all)]
 pub struct PyFootnoteDefinition {
     pub value: PyNodeFootnoteDefinition,
 }
 
-#[pyclass(name = "Table", extends=PyNodeValue, get_all)]
+#[pymethods]
+impl PyFootnoteDefinition {
+    #[new]
+    pub fn new(value: PyNodeFootnoteDefinition) -> (Self, PyNodeValue) {
+        (Self { value }, PyNodeValue::new())
+    }
+}
+
+#[pyclass(name = "Table", extends=PyNodeValue, get_all, set_all)]
 pub struct PyTable {
     pub value: PyNodeTable,
 }
 
-#[pyclass(name = "TableRow", extends=PyNodeValue, get_all)]
+#[pymethods]
+impl PyTable {
+    #[new]
+    pub fn new(value: PyNodeTable) -> (Self, PyNodeValue) {
+        (Self { value }, PyNodeValue::new())
+    }
+}
+
+#[pyclass(name = "TableRow", extends=PyNodeValue, get_all, set_all)]
 pub struct PyTableRow {
     pub value: bool,
+}
+
+#[pymethods]
+impl PyTableRow {
+    #[new]
+    pub fn new(value: bool) -> (Self, PyNodeValue) {
+        (Self { value }, PyNodeValue::new())
+    }
 }
 
 #[pyclass(name = "TableCell", extends=PyNodeValue)]
 pub struct PyTableCell {}
 
-#[pyclass(name = "Text", extends=PyNodeValue, get_all)]
+#[pymethods]
+impl PyTableCell {
+    #[new]
+    pub fn new() -> (Self, PyNodeValue) {
+        (Self {}, PyNodeValue::new())
+    }
+}
+
+#[pyclass(name = "Text", extends=PyNodeValue, get_all, set_all)]
 pub struct PyText {
     pub value: String,
 }
 
-#[pyclass(name = "TaskItem", extends=PyNodeValue, get_all)]
+#[pymethods]
+impl PyText {
+    #[new]
+
+    pub fn new(value: String) -> (Self, PyNodeValue) {
+        (Self { value }, PyNodeValue::new())
+    }
+}
+
+#[pyclass(name = "TaskItem", extends=PyNodeValue, get_all, set_all)]
 pub struct PyTaskItem {
     pub value: Option<char>,
+}
+
+#[pymethods]
+impl PyTaskItem {
+    #[new]
+    pub fn new(value: Option<char>) -> (Self, PyNodeValue) {
+        (Self { value }, PyNodeValue::new())
+    }
 }
 
 #[pyclass(name = "SoftBreak", extends=PyNodeValue)]
 pub struct PySoftBreak {}
 
+#[pymethods]
+impl PySoftBreak {
+    #[new]
+    pub fn new() -> (Self, PyNodeValue) {
+        (Self {}, PyNodeValue::new())
+    }
+}
+
 #[pyclass(name = "LineBreak", extends=PyNodeValue)]
 pub struct PyLineBreak {}
 
-#[pyclass(name = "Code", extends=PyNodeValue, get_all)]
+#[pymethods]
+impl PyLineBreak {
+    #[new]
+    pub fn new() -> (Self, PyNodeValue) {
+        (Self {}, PyNodeValue::new())
+    }
+}
+
+#[pyclass(name = "Code", extends=PyNodeValue, get_all, set_all)]
 pub struct PyCode {
     pub value: PyNodeCode,
 }
 
-#[pyclass(name = "HtmlInline", extends=PyNodeValue, get_all)]
+#[pymethods]
+impl PyCode {
+    #[new]
+    pub fn new(value: PyNodeCode) -> (Self, PyNodeValue) {
+        (Self { value }, PyNodeValue::new())
+    }
+}
+
+#[pyclass(name = "HtmlInline", extends=PyNodeValue, get_all, set_all)]
 pub struct PyHtmlInline {
     pub value: String,
 }
 
-#[pyclass(name = "Raw", extends=PyNodeValue, get_all)]
+#[pymethods]
+impl PyHtmlInline {
+    #[new]
+    pub fn new(value: String) -> (Self, PyNodeValue) {
+        (Self { value }, PyNodeValue::new())
+    }
+}
+
+#[pyclass(name = "Raw", extends=PyNodeValue, get_all, set_all)]
 pub struct PyRaw {
     pub value: String,
+}
+
+#[pymethods]
+impl PyRaw {
+    #[new]
+    pub fn new(value: String) -> (Self, PyNodeValue) {
+        (Self { value }, PyNodeValue::new())
+    }
 }
 
 #[pyclass(name = "Emph", extends=PyNodeValue)]
 pub struct PyEmph {}
 
+#[pymethods]
+impl PyEmph {
+    #[new]
+    pub fn new() -> (Self, PyNodeValue) {
+        (Self {}, PyNodeValue::new())
+    }
+}
+
 #[pyclass(name = "Strong", extends=PyNodeValue)]
 pub struct PyStrong {}
+
+#[pymethods]
+impl PyStrong {
+    #[new]
+    pub fn new() -> (Self, PyNodeValue) {
+        (Self {}, PyNodeValue::new())
+    }
+}
 
 #[pyclass(name = "Strikethrough", extends=PyNodeValue)]
 pub struct PyStrikethrough {}
 
+#[pymethods]
+impl PyStrikethrough {
+    #[new]
+    pub fn new() -> (Self, PyNodeValue) {
+        (Self {}, PyNodeValue::new())
+    }
+}
+
 #[pyclass(name = "Superscript", extends=PyNodeValue)]
 pub struct PySuperscript {}
 
-#[pyclass(name = "Link", extends=PyNodeValue, get_all)]
+#[pymethods]
+impl PySuperscript {
+    #[new]
+    pub fn new() -> (Self, PyNodeValue) {
+        (Self {}, PyNodeValue::new())
+    }
+}
+
+#[pyclass(name = "Link", extends=PyNodeValue, get_all, set_all)]
 pub struct PyLink {
     pub value: PyNodeLink,
 }
 
-#[pyclass(name = "Image", extends=PyNodeValue, get_all)]
+#[pymethods]
+impl PyLink {
+    #[new]
+    pub fn new(value: PyNodeLink) -> (Self, PyNodeValue) {
+        (Self { value }, PyNodeValue::new())
+    }
+}
+
+#[pyclass(name = "Image", extends=PyNodeValue, get_all, set_all)]
 pub struct PyImage {
     pub value: PyNodeLink,
 }
 
-#[pyclass(name = "FootnoteReference", extends=PyNodeValue, get_all)]
+#[pymethods]
+impl PyImage {
+    #[new]
+    pub fn new(value: PyNodeLink) -> (Self, PyNodeValue) {
+        (Self { value }, PyNodeValue::new())
+    }
+}
+
+#[pyclass(name = "FootnoteReference", extends=PyNodeValue, get_all, set_all)]
 pub struct PyFootnoteReference {
     pub value: PyNodeFootnoteReference,
 }
 
-#[pyclass(name = "ShortCode", extends=PyNodeValue, get_all)]
+#[pymethods]
+impl PyFootnoteReference {
+    #[new]
+    pub fn new(value: PyNodeFootnoteReference) -> (Self, PyNodeValue) {
+        (Self { value }, PyNodeValue::new())
+    }
+}
+
+#[pyclass(name = "ShortCode", extends=PyNodeValue, get_all, set_all)]
 pub struct PyShortCode {
     pub value: PyNodeShortCode,
 }
 
-#[pyclass(name = "Math", extends=PyNodeValue, get_all)]
+#[pymethods]
+impl PyShortCode {
+    #[new]
+    pub fn new(value: PyNodeShortCode) -> (Self, PyNodeValue) {
+        (Self { value }, PyNodeValue::new())
+    }
+}
+
+#[pyclass(name = "Math", extends=PyNodeValue, get_all, set_all)]
 pub struct PyMath {
     pub value: PyNodeMath,
 }
 
-#[pyclass(name = "MultilineBlockQuote", extends=PyNodeValue, get_all)]
+#[pymethods]
+impl PyMath {
+    #[new]
+    pub fn new(value: PyNodeMath) -> (Self, PyNodeValue) {
+        (Self { value }, PyNodeValue::new())
+    }
+}
+
+#[pyclass(name = "MultilineBlockQuote", extends=PyNodeValue, get_all, set_all)]
 pub struct PyMultilineBlockQuote {
     pub value: PyNodeMultilineBlockQuote,
+}
+
+#[pymethods]
+impl PyMultilineBlockQuote {
+    #[new]
+    pub fn new(value: PyNodeMultilineBlockQuote) -> (Self, PyNodeValue) {
+        (Self { value }, PyNodeValue::new())
+    }
 }
 
 #[pyclass(name = "Escaped", extends=PyNodeValue)]
 pub struct PyEscaped {}
 
-#[pyclass(name = "WikiLink", extends=PyNodeValue, get_all)]
+#[pymethods]
+impl PyEscaped {
+    #[new]
+    pub fn new() -> (Self, PyNodeValue) {
+        (Self {}, PyNodeValue::new())
+    }
+}
+
+#[pyclass(name = "WikiLink", extends=PyNodeValue, get_all, set_all)]
 pub struct PyWikiLink {
     pub value: PyNodeWikiLink,
+}
+
+#[pymethods]
+impl PyWikiLink {
+    #[new]
+    pub fn new(value: PyNodeWikiLink) -> (Self, PyNodeValue) {
+        (Self { value }, PyNodeValue::new())
+    }
 }
 
 #[pyclass(name = "Underline", extends=PyNodeValue)]
 pub struct PyUnderline {}
 
+#[pymethods]
+impl PyUnderline {
+    #[new]
+    pub fn new() -> (Self, PyNodeValue) {
+        (Self {}, PyNodeValue::new())
+    }
+}
+
 #[pyclass(name = "Subscript", extends=PyNodeValue)]
 pub struct PySubscript {}
+
+#[pymethods]
+impl PySubscript {
+    #[new]
+    pub fn new() -> (Self, PyNodeValue) {
+        (Self {}, PyNodeValue::new())
+    }
+}
 
 #[pyclass(name = "SpoileredText", extends=PyNodeValue)]
 pub struct PySpoileredText {}
 
-#[pyclass(name = "EscapedTag", extends=PyNodeValue, get_all)]
+#[pymethods]
+impl PySpoileredText {
+    #[new]
+    pub fn new() -> (Self, PyNodeValue) {
+        (Self {}, PyNodeValue::new())
+    }
+}
+
+#[pyclass(name = "EscapedTag", extends=PyNodeValue, get_all, set_all)]
 pub struct PyEscapedTag {
     pub value: String,
 }
 
-#[pyclass(name = "Alert", extends=PyNodeValue, get_all)]
+#[pymethods]
+impl PyEscapedTag {
+    #[new]
+    pub fn new(value: String) -> (Self, PyNodeValue) {
+        (Self { value }, PyNodeValue::new())
+    }
+}
+
+#[pyclass(name = "Alert", extends=PyNodeValue, get_all, set_all)]
 pub struct PyAlert {
     pub value: PyNodeAlert,
 }
 
+#[pymethods]
+impl PyAlert {
+    #[new]
+    pub fn new(value: PyNodeAlert) -> (Self, PyNodeValue) {
+        (Self { value }, PyNodeValue::new())
+    }
+}
 
-#[pyclass(name = "AstNode", get_all)]
+#[pyclass(name = "AstNode", get_all, set_all)]
 pub struct PyAstNode {
     pub node_value: PyObject,
     pub sourcepos: PySourcepos,
     pub children: Vec<Py<PyAstNode>>,
 }
 
-
-
 #[pymethods]
 impl PyAstNode {
     #[new]
     pub fn new(node_value: PyObject, sourcepos: PySourcepos, children: Vec<Py<PyAstNode>>) -> Self {
-        Self { node_value, sourcepos, children }
+        Self {
+            node_value,
+            sourcepos,
+            children,
+        }
     }
 }
 
 fn create_py_node_value(py: Python, value: &comrak_lib::nodes::NodeValue) -> PyObject {
     match value {
-        comrak_lib::nodes::NodeValue::Document => Py::new(py, PyClassInitializer::from(PyNodeValue {}).add_subclass( PyDocument {})).unwrap().into(),
-        comrak_lib::nodes::NodeValue::FrontMatter(s) => Py::new(py, PyClassInitializer::from(PyNodeValue {}).add_subclass(PyFrontMatter { value: s.clone() })).unwrap().into(),
-        comrak_lib::nodes::NodeValue::BlockQuote => Py::new(py, PyClassInitializer::from(PyNodeValue {}).add_subclass(PyBlockQuote {})).unwrap().into(),
-        comrak_lib::nodes::NodeValue::List(l) => Py::new(py, PyClassInitializer::from(PyNodeValue {}).add_subclass(PyList { value: PyNodeList::from(l) })).unwrap().into(),
-        comrak_lib::nodes::NodeValue::Item(i) => Py::new(py, PyClassInitializer::from(PyNodeValue {}).add_subclass(PyItem { value: PyNodeList::from(i) })).unwrap().into(),
-        comrak_lib::nodes::NodeValue::DescriptionList => Py::new(py, PyClassInitializer::from(PyNodeValue {}).add_subclass(PyDescriptionList {})).unwrap().into(),
-        comrak_lib::nodes::NodeValue::DescriptionItem(d) => Py::new(py, PyClassInitializer::from(PyNodeValue {}).add_subclass(PyDescriptionItem { value: PyNodeDescriptionItem::from(d) })).unwrap().into(),
-        comrak_lib::nodes::NodeValue::DescriptionTerm => Py::new(py, PyClassInitializer::from(PyNodeValue {}).add_subclass(PyDescriptionTerm {})).unwrap().into(),
-        comrak_lib::nodes::NodeValue::DescriptionDetails => Py::new(py, PyClassInitializer::from(PyNodeValue {}).add_subclass(PyDescriptionDetails {})).unwrap().into(),
-        comrak_lib::nodes::NodeValue::CodeBlock(c) => Py::new(py, PyClassInitializer::from(PyNodeValue {}).add_subclass(PyCodeBlock { value: PyNodeCodeBlock::from(c) })).unwrap().into(),
-        comrak_lib::nodes::NodeValue::HtmlBlock(h) => Py::new(py, PyClassInitializer::from(PyNodeValue {}).add_subclass(PyHtmlBlock { value: PyNodeHtmlBlock::from(h) })).unwrap().into(),
-        comrak_lib::nodes::NodeValue::Paragraph => Py::new(py, PyClassInitializer::from(PyNodeValue {}).add_subclass(PyParagraph {})).unwrap().into(),
-        comrak_lib::nodes::NodeValue::Heading(h) => Py::new(py, PyClassInitializer::from(PyNodeValue {}).add_subclass(PyHeading { value: PyNodeHeading::from(h) })).unwrap().into(),
-        comrak_lib::nodes::NodeValue::ThematicBreak => Py::new(py, PyClassInitializer::from(PyNodeValue {}).add_subclass(PyThematicBreak {})).unwrap().into(),
-        comrak_lib::nodes::NodeValue::FootnoteDefinition(f) => Py::new(py, PyClassInitializer::from(PyNodeValue {}).add_subclass(PyFootnoteDefinition { value: PyNodeFootnoteDefinition::from(f) })).unwrap().into(),
-        comrak_lib::nodes::NodeValue::Table(t) => Py::new(py, PyClassInitializer::from(PyNodeValue {}).add_subclass(PyTable { value: PyNodeTable::from(t) })).unwrap().into(),
-        comrak_lib::nodes::NodeValue::TableRow(is_header) => Py::new(py, PyClassInitializer::from(PyNodeValue {}).add_subclass(PyTableRow { value: *is_header })).unwrap().into(),
-        comrak_lib::nodes::NodeValue::TableCell => Py::new(py, PyClassInitializer::from(PyNodeValue {}).add_subclass(PyTableCell {})).unwrap().into(),
-        comrak_lib::nodes::NodeValue::Text(t) => Py::new(py, PyClassInitializer::from(PyNodeValue {}).add_subclass(PyText { value: t.clone() })).unwrap().into(),
-        comrak_lib::nodes::NodeValue::TaskItem(c) => Py::new(py, PyClassInitializer::from(PyNodeValue {}).add_subclass(PyTaskItem { value: *c })).unwrap().into(),
-        comrak_lib::nodes::NodeValue::SoftBreak => Py::new(py, PyClassInitializer::from(PyNodeValue {}).add_subclass(PySoftBreak {})).unwrap().into(),
-        comrak_lib::nodes::NodeValue::LineBreak => Py::new(py, PyClassInitializer::from(PyNodeValue {}).add_subclass(PyLineBreak {})).unwrap().into(),
-        comrak_lib::nodes::NodeValue::Code(c) => Py::new(py, PyClassInitializer::from(PyNodeValue {}).add_subclass(PyCode { value: PyNodeCode::from(c) })).unwrap().into(),
-        comrak_lib::nodes::NodeValue::HtmlInline(s) => Py::new(py, PyClassInitializer::from(PyNodeValue {}).add_subclass(PyHtmlInline { value: s.clone() })).unwrap().into(),
-        comrak_lib::nodes::NodeValue::Raw(s) => Py::new(py, PyClassInitializer::from(PyNodeValue {}).add_subclass(PyRaw { value: s.clone() })).unwrap().into(),
-        comrak_lib::nodes::NodeValue::Emph => Py::new(py, PyClassInitializer::from(PyNodeValue {}).add_subclass(PyEmph {})).unwrap().into(),
-        comrak_lib::nodes::NodeValue::Strong => Py::new(py, PyClassInitializer::from(PyNodeValue {}).add_subclass(PyStrong {})).unwrap().into(),
-        comrak_lib::nodes::NodeValue::Strikethrough => Py::new(py, PyClassInitializer::from(PyNodeValue {}).add_subclass(PyStrikethrough {})).unwrap().into(),
-        comrak_lib::nodes::NodeValue::Superscript => Py::new(py, PyClassInitializer::from(PyNodeValue {}).add_subclass(PySuperscript {})).unwrap().into(),
-        comrak_lib::nodes::NodeValue::Link(l) => Py::new(py, PyClassInitializer::from(PyNodeValue {}).add_subclass(PyLink { value: PyNodeLink::from(l) })).unwrap().into(),
-        comrak_lib::nodes::NodeValue::Image(i) => Py::new(py, PyClassInitializer::from(PyNodeValue {}).add_subclass(PyImage { value: PyNodeLink::from(i) })).unwrap().into(),
-        comrak_lib::nodes::NodeValue::FootnoteReference(f) => Py::new(py, PyClassInitializer::from(PyNodeValue {}).add_subclass(PyFootnoteReference { value: PyNodeFootnoteReference::from(f) })).unwrap().into(),
-        comrak_lib::nodes::NodeValue::ShortCode(s) => Py::new(py, PyClassInitializer::from(PyNodeValue {}).add_subclass(PyShortCode { value: PyNodeShortCode::from(s) })).unwrap().into(),
-        comrak_lib::nodes::NodeValue::Math(m) => Py::new(py, PyClassInitializer::from(PyNodeValue {}).add_subclass(PyMath { value: PyNodeMath::from(m) })).unwrap().into(),
-        comrak_lib::nodes::NodeValue::MultilineBlockQuote(m) => Py::new(py, PyClassInitializer::from(PyNodeValue {}).add_subclass(PyMultilineBlockQuote { value: PyNodeMultilineBlockQuote::from(m) })).unwrap().into(),
-        comrak_lib::nodes::NodeValue::Escaped => Py::new(py, PyClassInitializer::from(PyNodeValue {}).add_subclass(PyEscaped {})).unwrap().into(),
-        comrak_lib::nodes::NodeValue::WikiLink(w) => Py::new(py, PyClassInitializer::from(PyNodeValue {}).add_subclass(PyWikiLink { value: PyNodeWikiLink::from(w) })).unwrap().into(),
-        comrak_lib::nodes::NodeValue::Underline => Py::new(py, PyClassInitializer::from(PyNodeValue {}).add_subclass(PyUnderline {})).unwrap().into(),
-        comrak_lib::nodes::NodeValue::Subscript => Py::new(py, PyClassInitializer::from(PyNodeValue {}).add_subclass(PySubscript {})).unwrap().into(),
-        comrak_lib::nodes::NodeValue::SpoileredText => Py::new(py, PyClassInitializer::from(PyNodeValue {}).add_subclass(PySpoileredText {})).unwrap().into(),
-        comrak_lib::nodes::NodeValue::EscapedTag(s) => Py::new(py, PyClassInitializer::from(PyNodeValue {}).add_subclass(PyEscapedTag { value: s.clone() })).unwrap().into(),
-        comrak_lib::nodes::NodeValue::Alert(a) => Py::new(py, PyClassInitializer::from(PyNodeValue {}).add_subclass(PyAlert { value: PyNodeAlert::from(a) })).unwrap().into(),
+        comrak_lib::nodes::NodeValue::Document => Py::new(
+            py,
+            PyClassInitializer::from(PyNodeValue {}).add_subclass(PyDocument {}),
+        )
+        .unwrap()
+        .into(),
+        comrak_lib::nodes::NodeValue::FrontMatter(s) => Py::new(
+            py,
+            PyClassInitializer::from(PyNodeValue {})
+                .add_subclass(PyFrontMatter { value: s.clone() }),
+        )
+        .unwrap()
+        .into(),
+        comrak_lib::nodes::NodeValue::BlockQuote => Py::new(
+            py,
+            PyClassInitializer::from(PyNodeValue {}).add_subclass(PyBlockQuote {}),
+        )
+        .unwrap()
+        .into(),
+        comrak_lib::nodes::NodeValue::List(l) => Py::new(
+            py,
+            PyClassInitializer::from(PyNodeValue {}).add_subclass(PyList {
+                value: PyNodeList::from(l),
+            }),
+        )
+        .unwrap()
+        .into(),
+        comrak_lib::nodes::NodeValue::Item(i) => Py::new(
+            py,
+            PyClassInitializer::from(PyNodeValue {}).add_subclass(PyItem {
+                value: PyNodeList::from(i),
+            }),
+        )
+        .unwrap()
+        .into(),
+        comrak_lib::nodes::NodeValue::DescriptionList => Py::new(
+            py,
+            PyClassInitializer::from(PyNodeValue {}).add_subclass(PyDescriptionList {}),
+        )
+        .unwrap()
+        .into(),
+        comrak_lib::nodes::NodeValue::DescriptionItem(d) => Py::new(
+            py,
+            PyClassInitializer::from(PyNodeValue {}).add_subclass(PyDescriptionItem {
+                value: PyNodeDescriptionItem::from(d),
+            }),
+        )
+        .unwrap()
+        .into(),
+        comrak_lib::nodes::NodeValue::DescriptionTerm => Py::new(
+            py,
+            PyClassInitializer::from(PyNodeValue {}).add_subclass(PyDescriptionTerm {}),
+        )
+        .unwrap()
+        .into(),
+        comrak_lib::nodes::NodeValue::DescriptionDetails => Py::new(
+            py,
+            PyClassInitializer::from(PyNodeValue {}).add_subclass(PyDescriptionDetails {}),
+        )
+        .unwrap()
+        .into(),
+        comrak_lib::nodes::NodeValue::CodeBlock(c) => Py::new(
+            py,
+            PyClassInitializer::from(PyNodeValue {}).add_subclass(PyCodeBlock {
+                value: PyNodeCodeBlock::from(c),
+            }),
+        )
+        .unwrap()
+        .into(),
+        comrak_lib::nodes::NodeValue::HtmlBlock(h) => Py::new(
+            py,
+            PyClassInitializer::from(PyNodeValue {}).add_subclass(PyHtmlBlock {
+                value: PyNodeHtmlBlock::from(h),
+            }),
+        )
+        .unwrap()
+        .into(),
+        comrak_lib::nodes::NodeValue::Paragraph => Py::new(
+            py,
+            PyClassInitializer::from(PyNodeValue {}).add_subclass(PyParagraph {}),
+        )
+        .unwrap()
+        .into(),
+        comrak_lib::nodes::NodeValue::Heading(h) => Py::new(
+            py,
+            PyClassInitializer::from(PyNodeValue {}).add_subclass(PyHeading {
+                value: PyNodeHeading::from(h),
+            }),
+        )
+        .unwrap()
+        .into(),
+        comrak_lib::nodes::NodeValue::ThematicBreak => Py::new(
+            py,
+            PyClassInitializer::from(PyNodeValue {}).add_subclass(PyThematicBreak {}),
+        )
+        .unwrap()
+        .into(),
+        comrak_lib::nodes::NodeValue::FootnoteDefinition(f) => Py::new(
+            py,
+            PyClassInitializer::from(PyNodeValue {}).add_subclass(PyFootnoteDefinition {
+                value: PyNodeFootnoteDefinition::from(f),
+            }),
+        )
+        .unwrap()
+        .into(),
+        comrak_lib::nodes::NodeValue::Table(t) => Py::new(
+            py,
+            PyClassInitializer::from(PyNodeValue {}).add_subclass(PyTable {
+                value: PyNodeTable::from(t),
+            }),
+        )
+        .unwrap()
+        .into(),
+        comrak_lib::nodes::NodeValue::TableRow(is_header) => Py::new(
+            py,
+            PyClassInitializer::from(PyNodeValue {}).add_subclass(PyTableRow { value: *is_header }),
+        )
+        .unwrap()
+        .into(),
+        comrak_lib::nodes::NodeValue::TableCell => Py::new(
+            py,
+            PyClassInitializer::from(PyNodeValue {}).add_subclass(PyTableCell {}),
+        )
+        .unwrap()
+        .into(),
+        comrak_lib::nodes::NodeValue::Text(t) => Py::new(
+            py,
+            PyClassInitializer::from(PyNodeValue {}).add_subclass(PyText { value: t.clone() }),
+        )
+        .unwrap()
+        .into(),
+        comrak_lib::nodes::NodeValue::TaskItem(c) => Py::new(
+            py,
+            PyClassInitializer::from(PyNodeValue {}).add_subclass(PyTaskItem { value: *c }),
+        )
+        .unwrap()
+        .into(),
+        comrak_lib::nodes::NodeValue::SoftBreak => Py::new(
+            py,
+            PyClassInitializer::from(PyNodeValue {}).add_subclass(PySoftBreak {}),
+        )
+        .unwrap()
+        .into(),
+        comrak_lib::nodes::NodeValue::LineBreak => Py::new(
+            py,
+            PyClassInitializer::from(PyNodeValue {}).add_subclass(PyLineBreak {}),
+        )
+        .unwrap()
+        .into(),
+        comrak_lib::nodes::NodeValue::Code(c) => Py::new(
+            py,
+            PyClassInitializer::from(PyNodeValue {}).add_subclass(PyCode {
+                value: PyNodeCode::from(c),
+            }),
+        )
+        .unwrap()
+        .into(),
+        comrak_lib::nodes::NodeValue::HtmlInline(s) => Py::new(
+            py,
+            PyClassInitializer::from(PyNodeValue {})
+                .add_subclass(PyHtmlInline { value: s.clone() }),
+        )
+        .unwrap()
+        .into(),
+        comrak_lib::nodes::NodeValue::Raw(s) => Py::new(
+            py,
+            PyClassInitializer::from(PyNodeValue {}).add_subclass(PyRaw { value: s.clone() }),
+        )
+        .unwrap()
+        .into(),
+        comrak_lib::nodes::NodeValue::Emph => Py::new(
+            py,
+            PyClassInitializer::from(PyNodeValue {}).add_subclass(PyEmph {}),
+        )
+        .unwrap()
+        .into(),
+        comrak_lib::nodes::NodeValue::Strong => Py::new(
+            py,
+            PyClassInitializer::from(PyNodeValue {}).add_subclass(PyStrong {}),
+        )
+        .unwrap()
+        .into(),
+        comrak_lib::nodes::NodeValue::Strikethrough => Py::new(
+            py,
+            PyClassInitializer::from(PyNodeValue {}).add_subclass(PyStrikethrough {}),
+        )
+        .unwrap()
+        .into(),
+        comrak_lib::nodes::NodeValue::Superscript => Py::new(
+            py,
+            PyClassInitializer::from(PyNodeValue {}).add_subclass(PySuperscript {}),
+        )
+        .unwrap()
+        .into(),
+        comrak_lib::nodes::NodeValue::Link(l) => Py::new(
+            py,
+            PyClassInitializer::from(PyNodeValue {}).add_subclass(PyLink {
+                value: PyNodeLink::from(l),
+            }),
+        )
+        .unwrap()
+        .into(),
+        comrak_lib::nodes::NodeValue::Image(i) => Py::new(
+            py,
+            PyClassInitializer::from(PyNodeValue {}).add_subclass(PyImage {
+                value: PyNodeLink::from(i),
+            }),
+        )
+        .unwrap()
+        .into(),
+        comrak_lib::nodes::NodeValue::FootnoteReference(f) => Py::new(
+            py,
+            PyClassInitializer::from(PyNodeValue {}).add_subclass(PyFootnoteReference {
+                value: PyNodeFootnoteReference::from(f),
+            }),
+        )
+        .unwrap()
+        .into(),
+        comrak_lib::nodes::NodeValue::ShortCode(s) => Py::new(
+            py,
+            PyClassInitializer::from(PyNodeValue {}).add_subclass(PyShortCode {
+                value: PyNodeShortCode::from(s),
+            }),
+        )
+        .unwrap()
+        .into(),
+        comrak_lib::nodes::NodeValue::Math(m) => Py::new(
+            py,
+            PyClassInitializer::from(PyNodeValue {}).add_subclass(PyMath {
+                value: PyNodeMath::from(m),
+            }),
+        )
+        .unwrap()
+        .into(),
+        comrak_lib::nodes::NodeValue::MultilineBlockQuote(m) => Py::new(
+            py,
+            PyClassInitializer::from(PyNodeValue {}).add_subclass(PyMultilineBlockQuote {
+                value: PyNodeMultilineBlockQuote::from(m),
+            }),
+        )
+        .unwrap()
+        .into(),
+        comrak_lib::nodes::NodeValue::Escaped => Py::new(
+            py,
+            PyClassInitializer::from(PyNodeValue {}).add_subclass(PyEscaped {}),
+        )
+        .unwrap()
+        .into(),
+        comrak_lib::nodes::NodeValue::WikiLink(w) => Py::new(
+            py,
+            PyClassInitializer::from(PyNodeValue {}).add_subclass(PyWikiLink {
+                value: PyNodeWikiLink::from(w),
+            }),
+        )
+        .unwrap()
+        .into(),
+        comrak_lib::nodes::NodeValue::Underline => Py::new(
+            py,
+            PyClassInitializer::from(PyNodeValue {}).add_subclass(PyUnderline {}),
+        )
+        .unwrap()
+        .into(),
+        comrak_lib::nodes::NodeValue::Subscript => Py::new(
+            py,
+            PyClassInitializer::from(PyNodeValue {}).add_subclass(PySubscript {}),
+        )
+        .unwrap()
+        .into(),
+        comrak_lib::nodes::NodeValue::SpoileredText => Py::new(
+            py,
+            PyClassInitializer::from(PyNodeValue {}).add_subclass(PySpoileredText {}),
+        )
+        .unwrap()
+        .into(),
+        comrak_lib::nodes::NodeValue::EscapedTag(s) => Py::new(
+            py,
+            PyClassInitializer::from(PyNodeValue {})
+                .add_subclass(PyEscapedTag { value: s.clone() }),
+        )
+        .unwrap()
+        .into(),
+        comrak_lib::nodes::NodeValue::Alert(a) => Py::new(
+            py,
+            PyClassInitializer::from(PyNodeValue {}).add_subclass(PyAlert {
+                value: PyNodeAlert::from(a),
+            }),
+        )
+        .unwrap()
+        .into(),
     }
 }
-
 
 impl PyAstNode {
     pub fn from_comrak_node<'a>(py: Python<'a>, node: &'a AstNode<'a>) -> Py<PyAstNode> {
         let ast = node.data.borrow();
         let node_value = create_py_node_value(py, &ast.value);
         let sourcepos: PySourcepos = PySourcepos::from(&ast.sourcepos);
-        let children = node.children().map(|child| Self::from_comrak_node(py, child)).collect();
+        let children = node
+            .children()
+            .map(|child| Self::from_comrak_node(py, child))
+            .collect();
         Py::new(py, PyAstNode::new(node_value, sourcepos, children)).unwrap()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,28 +1,30 @@
 use pyo3::prelude::*;
 
 // We renamed the Rust library to `comrak_lib`
-use comrak_lib::{markdown_to_html, markdown_to_commonmark, parse_document, Options as ComrakOptions, Arena};
+use comrak_lib::{
+    markdown_to_commonmark, markdown_to_html, parse_document, Arena, Options as ComrakOptions,
+};
 
 // Import the Python option classes we defined
 mod options;
-use options::{PyExtensionOptions, PyParseOptions, PyRenderOptions, PyListStyleType};
+use options::{PyExtensionOptions, PyListStyleType, PyParseOptions, PyRenderOptions};
 mod astnode;
 use astnode::{
-    PyLineColumn, PySourcepos, PyNodeCode, PyNodeHtmlBlock, PyListDelimType, PyListType,
-    PyTableAlignment, PyNodeList, PyNodeDescriptionItem, PyNodeCodeBlock, PyNodeHeading,
-    PyNodeTable, PyNodeLink, PyNodeFootnoteDefinition, PyNodeFootnoteReference, PyNodeWikiLink,
-    PyNodeShortCode, PyNodeMath, PyNodeMultilineBlockQuote, PyAlertType, PyNodeAlert,
-    PyNodeValue, PyDocument, PyFrontMatter, PyBlockQuote, PyList, PyItem, PyDescriptionList,
-    PyDescriptionItem, PyDescriptionTerm, PyDescriptionDetails, PyCodeBlock, PyHtmlBlock,
-    PyParagraph, PyHeading, PyThematicBreak, PyFootnoteDefinition, PyTable, PyTableRow,
-    PyTableCell, PyText, PyTaskItem, PySoftBreak, PyLineBreak, PyCode, PyHtmlInline, PyRaw,
-    PyEmph, PyStrong, PyStrikethrough, PySuperscript, PyLink, PyImage, PyFootnoteReference,
-    PyShortCode, PyMath, PyMultilineBlockQuote, PyEscaped, PyWikiLink, PyUnderline,
-    PySubscript, PySpoileredText, PyEscapedTag, PyAlert, PyAstNode
+    PyAlert, PyAlertType, PyAstNode, PyBlockQuote, PyCode, PyCodeBlock, PyDescriptionDetails,
+    PyDescriptionItem, PyDescriptionList, PyDescriptionTerm, PyDocument, PyEmph, PyEscaped,
+    PyEscapedTag, PyFootnoteDefinition, PyFootnoteReference, PyFrontMatter, PyHeading, PyHtmlBlock,
+    PyHtmlInline, PyImage, PyItem, PyLineBreak, PyLineColumn, PyLink, PyList, PyListDelimType,
+    PyListType, PyMath, PyMultilineBlockQuote, PyNodeAlert, PyNodeCode, PyNodeCodeBlock,
+    PyNodeDescriptionItem, PyNodeFootnoteDefinition, PyNodeFootnoteReference, PyNodeHeading,
+    PyNodeHtmlBlock, PyNodeLink, PyNodeList, PyNodeMath, PyNodeMultilineBlockQuote,
+    PyNodeShortCode, PyNodeTable, PyNodeValue, PyNodeWikiLink, PyParagraph, PyRaw, PyShortCode,
+    PySoftBreak, PySourcepos, PySpoileredText, PyStrikethrough, PyStrong, PySubscript,
+    PySuperscript, PyTable, PyTableAlignment, PyTableCell, PyTableRow, PyTaskItem, PyText,
+    PyThematicBreak, PyUnderline, PyWikiLink,
 };
 
 /// Render a Markdown string to HTML, with optional Extension/Parse/Render overrides.
-#[pyfunction(signature=(text, extension_options=None, parse_options=None, render_options=None))]
+#[pyfunction(name = "markdown_to_html", signature=(text, extension_options=None, parse_options=None, render_options=None))]
 fn render_markdown(
     text: &str,
     extension_options: Option<PyExtensionOptions>,
@@ -49,7 +51,7 @@ fn render_markdown(
 }
 
 /// Convert a Markdown string to CommonMark format.
-#[pyfunction(signature=(text, extension_options=None, parse_options=None, render_options=None))]
+#[pyfunction(name = "markdown_to_commonmark", signature=(text, extension_options=None, parse_options=None, render_options=None))]
 fn render_markdown_to_commonmark(
     text: &str,
     extension_options: Option<PyExtensionOptions>,
@@ -76,7 +78,7 @@ fn render_markdown_to_commonmark(
 }
 
 // Parse a Markdown string into a document structure and return as PyAstNode.
-#[pyfunction(signature=(text, extension_options=None, parse_options=None, render_options=None))]
+#[pyfunction(name = "parse_document", signature=(text, extension_options=None, parse_options=None, render_options=None))]
 fn parse_markdown(
     py: Python,
     text: &str,

--- a/src/options.rs
+++ b/src/options.rs
@@ -7,52 +7,30 @@ use comrak_lib::{
 };
 
 /// Python class that mirrors Comrak’s `ExtensionOptions`
-#[pyclass(name = "ExtensionOptions")]
+#[pyclass(name = "ExtensionOptions", get_all, set_all)]
 #[derive(Clone)]
 pub struct PyExtensionOptions {
-    #[pyo3(get, set)]
     pub strikethrough: bool,
-    #[pyo3(get, set)]
     pub tagfilter: bool,
-    #[pyo3(get, set)]
     pub table: bool,
-    #[pyo3(get, set)]
     pub autolink: bool,
-    #[pyo3(get, set)]
     pub tasklist: bool,
-    #[pyo3(get, set)]
     pub superscript: bool,
-    #[pyo3(get, set)]
     pub header_ids: Option<String>,
-    #[pyo3(get, set)]
     pub footnotes: bool,
-    #[pyo3(get, set)]
     pub description_lists: bool,
-    #[pyo3(get, set)]
     pub front_matter_delimiter: Option<String>,
-    #[pyo3(get, set)]
     pub multiline_block_quotes: bool,
-    #[pyo3(get, set)]
     pub alerts: bool,
-    #[pyo3(get, set)]
     pub math_dollars: bool,
-    #[pyo3(get, set)]
     pub math_code: bool,
-    #[pyo3(get, set)]
     pub shortcodes: bool, // if your comrak_lib has the "shortcodes" feature
-    #[pyo3(get, set)]
     pub wikilinks_title_after_pipe: bool,
-    #[pyo3(get, set)]
     pub wikilinks_title_before_pipe: bool,
-    #[pyo3(get, set)]
     pub underline: bool,
-    #[pyo3(get, set)]
     pub subscript: bool,
-    #[pyo3(get, set)]
     pub spoiler: bool,
-    #[pyo3(get, set)]
     pub greentext: bool,
-    #[pyo3(get, set)]
     pub cjk_friendly_emphasis: bool,
 }
 
@@ -87,46 +65,93 @@ impl PyExtensionOptions {
 #[pymethods]
 impl PyExtensionOptions {
     #[new]
-    pub fn new() -> Self {
+    #[pyo3(signature = (
+        strikethrough=None,
+        tagfilter=None,
+        table=None,
+        autolink=None,
+        tasklist=None,
+        superscript=None,
+        header_ids=None,
+        footnotes=None,
+        description_lists=None,
+        front_matter_delimiter=None,
+        multiline_block_quotes=None,
+        alerts=None,
+        math_dollars=None,
+        math_code=None,
+        shortcodes=None, // if your comrak_lib has the "shortcodes" feature
+        wikilinks_title_after_pipe=None,
+        wikilinks_title_before_pipe=None,
+        underline=None,
+        subscript=None,
+        spoiler=None,
+        greentext=None,
+        cjk_friendly_emphasis=None,
+    ))]
+    pub fn new(
+        strikethrough: Option<bool>,
+        tagfilter: Option<bool>,
+        table: Option<bool>,
+        autolink: Option<bool>,
+        tasklist: Option<bool>,
+        superscript: Option<bool>,
+        header_ids: Option<String>,
+        footnotes: Option<bool>,
+        description_lists: Option<bool>,
+        front_matter_delimiter: Option<String>,
+        multiline_block_quotes: Option<bool>,
+        alerts: Option<bool>,
+        math_dollars: Option<bool>,
+        math_code: Option<bool>,
+        shortcodes: Option<bool>, // if your comrak_lib has the "shortcodes" feature
+        wikilinks_title_after_pipe: Option<bool>,
+        wikilinks_title_before_pipe: Option<bool>,
+        underline: Option<bool>,
+        subscript: Option<bool>,
+        spoiler: Option<bool>,
+        greentext: Option<bool>,
+        cjk_friendly_emphasis: Option<bool>,
+    ) -> Self {
         let defaults = ComrakExtensionOptions::default();
         Self {
-            strikethrough: defaults.strikethrough,
-            tagfilter: defaults.tagfilter,
-            table: defaults.table,
-            autolink: defaults.autolink,
-            tasklist: defaults.tasklist,
-            superscript: defaults.superscript,
-            header_ids: defaults.header_ids.clone(),
-            footnotes: defaults.footnotes,
-            description_lists: defaults.description_lists,
-            front_matter_delimiter: defaults.front_matter_delimiter.clone(),
-            multiline_block_quotes: defaults.multiline_block_quotes,
-            alerts: defaults.alerts,
-            math_dollars: defaults.math_dollars,
-            math_code: defaults.math_code,
-            shortcodes: false, // or `defaults.shortcodes` if your version has that
-            wikilinks_title_after_pipe: defaults.wikilinks_title_after_pipe,
-            wikilinks_title_before_pipe: defaults.wikilinks_title_before_pipe,
-            underline: defaults.underline,
-            subscript: defaults.subscript,
-            spoiler: defaults.spoiler,
-            greentext: defaults.greentext,
-            cjk_friendly_emphasis: defaults.cjk_friendly_emphasis,
+            strikethrough: strikethrough.unwrap_or(defaults.strikethrough),
+            tagfilter: tagfilter.unwrap_or(defaults.tagfilter),
+            table: table.unwrap_or(defaults.table),
+            autolink: autolink.unwrap_or(defaults.autolink),
+            tasklist: tasklist.unwrap_or(defaults.tasklist),
+            superscript: superscript.unwrap_or(defaults.superscript),
+            header_ids: header_ids.or(defaults.header_ids.clone()),
+            footnotes: footnotes.unwrap_or(defaults.footnotes),
+            description_lists: description_lists.unwrap_or(defaults.description_lists),
+            front_matter_delimiter: front_matter_delimiter
+                .or(defaults.front_matter_delimiter.clone()),
+            multiline_block_quotes: multiline_block_quotes
+                .unwrap_or(defaults.multiline_block_quotes),
+            alerts: alerts.unwrap_or(defaults.alerts),
+            math_dollars: math_dollars.unwrap_or(defaults.math_dollars),
+            math_code: math_code.unwrap_or(defaults.math_code),
+            shortcodes: shortcodes.unwrap_or(defaults.shortcodes),
+            wikilinks_title_after_pipe: wikilinks_title_after_pipe
+                .unwrap_or(defaults.wikilinks_title_after_pipe),
+            wikilinks_title_before_pipe: wikilinks_title_before_pipe
+                .unwrap_or(defaults.wikilinks_title_before_pipe),
+            underline: underline.unwrap_or(defaults.underline),
+            subscript: subscript.unwrap_or(defaults.subscript),
+            spoiler: spoiler.unwrap_or(defaults.spoiler),
+            greentext: greentext.unwrap_or(defaults.greentext),
+            cjk_friendly_emphasis: cjk_friendly_emphasis.unwrap_or(defaults.cjk_friendly_emphasis),
         }
     }
 }
 
 /// Python class that mirrors Comrak’s `ParseOptions`
-#[pyclass(name = "ParseOptions")]
+#[pyclass(name = "ParseOptions", get_all, set_all)]
 #[derive(Clone)]
 pub struct PyParseOptions {
-    #[pyo3(get, set)]
     pub smart: bool,
-    #[pyo3(get, set)]
     pub default_info_string: Option<String>,
-    #[pyo3(get, set)]
     pub relaxed_tasklist_matching: bool,
-    #[pyo3(get, set)]
     pub relaxed_autolinks: bool,
 }
 
@@ -143,19 +168,26 @@ impl PyParseOptions {
 #[pymethods]
 impl PyParseOptions {
     #[new]
-    pub fn new() -> Self {
+    #[pyo3(signature = (smart=None, default_info_string=None, relaxed_tasklist_matching=None, relaxed_autolinks=None))]
+    pub fn new(
+        smart: Option<bool>,
+        default_info_string: Option<String>,
+        relaxed_tasklist_matching: Option<bool>,
+        relaxed_autolinks: Option<bool>,
+    ) -> Self {
         let defaults = ComrakParseOptions::default();
         Self {
-            smart: defaults.smart,
-            default_info_string: defaults.default_info_string.clone(),
-            relaxed_tasklist_matching: defaults.relaxed_tasklist_matching,
-            relaxed_autolinks: defaults.relaxed_autolinks,
+            smart: smart.unwrap_or(defaults.smart),
+            default_info_string: default_info_string.or(defaults.default_info_string.clone()),
+            relaxed_tasklist_matching: relaxed_tasklist_matching
+                .unwrap_or(defaults.relaxed_tasklist_matching),
+            relaxed_autolinks: relaxed_autolinks.unwrap_or(defaults.relaxed_autolinks),
         }
     }
 }
 
-#[pyclass(name="ListStyleType")]
-#[derive(Clone)]
+#[pyclass(name = "ListStyleType", eq, eq_int)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub enum PyListStyleType {
     Dash = 45,
     Plus = 43,
@@ -163,42 +195,25 @@ pub enum PyListStyleType {
 }
 
 /// Python class that mirrors Comrak’s `RenderOptions`
-#[pyclass(name = "RenderOptions")]
+#[pyclass(name = "RenderOptions", get_all, set_all)]
 #[derive(Clone)]
 pub struct PyRenderOptions {
-    #[pyo3(get, set)]
     pub hardbreaks: bool,
-    #[pyo3(get, set)]
     pub github_pre_lang: bool,
-    #[pyo3(get, set)]
     pub full_info_string: bool,
-    #[pyo3(get, set)]
     pub width: usize,
-    #[pyo3(get, set)]
     pub unsafe_: bool, // named 'unsafe_' because 'unsafe' is reserved
-    #[pyo3(get, set)]
     pub escape: bool,
-    #[pyo3(get, set)]
     pub list_style: PyListStyleType,
-    #[pyo3(get, set)]
     pub sourcepos: bool,
-    #[pyo3(get, set)]
     pub escaped_char_spans: bool,
-    #[pyo3(get, set)]
     pub ignore_setext: bool,
-    #[pyo3(get, set)]
     pub ignore_empty_links: bool,
-    #[pyo3(get, set)]
     pub gfm_quirks: bool,
-    #[pyo3(get, set)]
     pub prefer_fenced: bool,
-    #[pyo3(get, set)]
     pub figure_with_caption: bool,
-    #[pyo3(get, set)]
     pub tasklist_classes: bool,
-    #[pyo3(get, set)]
     pub ol_width: usize,
-    #[pyo3(get, set)]
     pub experimental_minimize_commonmark: bool,
 }
 
@@ -233,30 +248,68 @@ impl PyRenderOptions {
 #[pymethods]
 impl PyRenderOptions {
     #[new]
-    pub fn new() -> Self {
+    #[pyo3(signature = (
+        hardbreaks=None,
+        github_pre_lang=None,
+        full_info_string=None,
+        width=None,
+        unsafe_=None,
+        escape=None,
+        list_style=None,
+        sourcepos=None,
+        escaped_char_spans=None,
+        ignore_setext=None,
+        ignore_empty_links=None,
+        gfm_quirks=None,
+        prefer_fenced=None,
+        figure_with_caption=None,
+        tasklist_classes=None,
+        ol_width=None,
+        experimental_minimize_commonmark=None,
+    ))]
+    pub fn new(
+        hardbreaks: Option<bool>,
+        github_pre_lang: Option<bool>,
+        full_info_string: Option<bool>,
+        width: Option<usize>,
+        unsafe_: Option<bool>,
+        escape: Option<bool>,
+        list_style: Option<PyListStyleType>,
+        sourcepos: Option<bool>,
+        escaped_char_spans: Option<bool>,
+        ignore_setext: Option<bool>,
+        ignore_empty_links: Option<bool>,
+        gfm_quirks: Option<bool>,
+        prefer_fenced: Option<bool>,
+        figure_with_caption: Option<bool>,
+        tasklist_classes: Option<bool>,
+        ol_width: Option<usize>,
+        experimental_minimize_commonmark: Option<bool>,
+    ) -> Self {
         let defaults = ComrakRenderOptions::default();
         Self {
-            hardbreaks: defaults.hardbreaks,
-            github_pre_lang: defaults.github_pre_lang,
-            full_info_string: defaults.full_info_string,
-            width: defaults.width,
-            unsafe_: defaults.unsafe_,
-            escape: defaults.escape,
-            list_style: match defaults.list_style {
+            hardbreaks: hardbreaks.unwrap_or(defaults.hardbreaks),
+            github_pre_lang: github_pre_lang.unwrap_or(defaults.github_pre_lang),
+            full_info_string: full_info_string.unwrap_or(defaults.full_info_string),
+            width: width.unwrap_or(defaults.width),
+            unsafe_: unsafe_.unwrap_or(defaults.unsafe_),
+            escape: escape.unwrap_or(defaults.escape),
+            list_style: list_style.unwrap_or(match defaults.list_style {
                 comrak_lib::ListStyleType::Dash => PyListStyleType::Dash,
                 comrak_lib::ListStyleType::Plus => PyListStyleType::Plus,
                 comrak_lib::ListStyleType::Star => PyListStyleType::Star,
-            },
-            sourcepos: defaults.sourcepos,
-            escaped_char_spans: defaults.escaped_char_spans,
-            ignore_setext: defaults.ignore_setext,
-            ignore_empty_links: defaults.ignore_empty_links,
-            gfm_quirks: defaults.gfm_quirks,
-            prefer_fenced: defaults.prefer_fenced,
-            figure_with_caption: defaults.figure_with_caption,
-            tasklist_classes: defaults.tasklist_classes,
-            ol_width: defaults.ol_width,
-            experimental_minimize_commonmark: defaults.experimental_minimize_commonmark,
+            }),
+            sourcepos: sourcepos.unwrap_or(defaults.sourcepos),
+            escaped_char_spans: escaped_char_spans.unwrap_or(defaults.escaped_char_spans),
+            ignore_setext: ignore_setext.unwrap_or(defaults.ignore_setext),
+            ignore_empty_links: ignore_empty_links.unwrap_or(defaults.ignore_empty_links),
+            gfm_quirks: gfm_quirks.unwrap_or(defaults.gfm_quirks),
+            prefer_fenced: prefer_fenced.unwrap_or(defaults.prefer_fenced),
+            figure_with_caption: figure_with_caption.unwrap_or(defaults.figure_with_caption),
+            tasklist_classes: tasklist_classes.unwrap_or(defaults.tasklist_classes),
+            ol_width: ol_width.unwrap_or(defaults.ol_width),
+            experimental_minimize_commonmark: experimental_minimize_commonmark
+                .unwrap_or(defaults.experimental_minimize_commonmark),
         }
     }
 }


### PR DESCRIPTION
- Updated `PyExtensionOptions`, `PyParseOptions`, and `PyRenderOptions` to use `get_all` and `set_all` attributes for automatic getter and setter generation.
- Modified constructors to accept optional parameters, allowing users to specify only the options they want to override.
- Renamed functions in `lib.rs` to include explicit names for better clarity when called from Python.
- Cleaned up import statements for better organization and readability.