### PR TITLE
feat: Add parent reference to AstNode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,7 +219,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "comrak"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "comrak 0.41.0",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ crate-type = ["cdylib"]
 
 [package]
 name = "comrak"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 
 [profile.release]

--- a/comrak.pyi
+++ b/comrak.pyi
@@ -318,9 +318,14 @@ class Sourcepos:
 class AstNode:
     node_value: NodeValue
     sourcepos: Sourcepos
+    parent: Optional[AstNode]
     children: list[AstNode]
     def __init__(
-        self, node_value: NodeValue, sourcepos: Sourcepos, children: list[AstNode]
+        self,
+        node_value: NodeValue,
+        sourcepos: Sourcepos,
+        parent: Optional[AstNode],
+        children: list[AstNode],
     ) -> None: ...
 
 class ExtensionOptions:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ keywords = [
 ]
 readme = "README.md"
 requires-python = ">=3.9"
-version = "0.1.2"
+version = "0.1.3"
 
 [project.license]
 file = "LICENSE"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@ fn parse_markdown(
 
     let arena = Arena::new();
     let document = parse_document(&arena, text, &opts);
-    let py_node = PyAstNode::from_comrak_node(py, document);
+    let py_node = PyAstNode::from_comrak_node(py, document, None);
     Ok(py_node)
 }
 


### PR DESCRIPTION
This pull request introduces a minor version bump and enhances the AST node structure by adding parent references to each node. This change allows for easier navigation from a child node to its parent in the AST, which can be useful for various tree traversal and manipulation tasks. The update touches both the Rust and Python layers to ensure the new `parent` field is properly exposed and initialized.

### AST Node Structure Enhancements

* Added a `parent` field to the `PyAstNode` struct in Rust, allowing each node to reference its parent node. The `from_comrak_node` method now takes an optional parent reference and sets it appropriately when constructing the AST. (`src/astnode.rs`) [[1]](diffhunk://#diff-efdec6354480057065a2ae9df10063cfed83119dd1a10cac520940c5816167bbR1166) [[2]](diffhunk://#diff-efdec6354480057065a2ae9df10063cfed83119dd1a10cac520940c5816167bbL1476-R1506)
* Updated the Python interface (`comrak.pyi`) to include the new `parent` attribute on `AstNode`, ensuring Python consumers can access parent nodes. The constructor signature was also updated to accept the parent parameter.

### API and Versioning

* Bumped the version number from `0.1.2` to `0.1.3` in both `Cargo.toml` and `pyproject.toml` to reflect the new feature. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L11-R11) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L37-R37)

### Internal API Changes

* Updated the `parse_markdown` function to pass the new parent parameter (`None` for the root node) when constructing the AST. (`src/lib.rs`)
* Modified the `PyAstNode::new` constructor to initialize the `parent` field to `None` by default. (`src/astnode.rs`)