### PR TITLE
feat: Update Comrak to v0.51.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,18 +10,18 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "anstream"
-version = "0.6.20"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -34,9 +34,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.11"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
@@ -49,22 +49,22 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.10"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -90,36 +90,30 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.5.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
  "bit-vec",
 ]
 
 [[package]]
 name = "bit-vec"
-version = "0.6.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
-version = "2.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "bon"
-version = "3.7.1"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537c317ddf588aab15c695bf92cf55dec159b93221c074180ca3e0e5a94da415"
+checksum = "2d13a61f2963b88eef9c1be03df65d42f6996dfeac1054870d950fcf66686f83"
 dependencies = [
  "bon-macros",
  "rustversion",
@@ -127,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "bon-macros"
-version = "3.7.1"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca5abbf2d4a4c6896197c9de13d6d7cb7eff438c63dacde1dde980569cb00248"
+checksum = "d314cc62af2b6b0c65780555abb4d02a03dd3b799cd42419044f0c38d99738c0"
 dependencies = [
  "darling",
  "ident_case",
@@ -151,24 +145,25 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.34"
+version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42bc4aea80032b7bf409b0bc7ccad88853858911b7713a8062fdc0623867bedc"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.5.46"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c5e4fcf9c21d2e544ca1ee9d8552de13019a42aa7dbf32747fa7aaf1df76e57"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -176,9 +171,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.46"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecb53a0e6fcfb055f686001bc2e2592fa527efaf38dbe81a6a9563562e57d41"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
 dependencies = [
  "anstream",
  "anstyle",
@@ -189,9 +184,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.45"
+version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14cb31bb0a7d536caef2639baa7fad459e15c3144efefa6dbd1c84562c4739f6"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -201,9 +196,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "colorchoice"
@@ -213,23 +208,16 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "comrak"
-version = "0.1.6"
-dependencies = [
- "comrak 0.50.0",
- "pyo3",
-]
-
-[[package]]
-name = "comrak"
-version = "0.50.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321d20bf105b6871a49da44c5fbb93e90a7cd6178ea5a9fe6cbc1e6d4504bc5e"
+checksum = "9f07383e7799d964bf7ffa6fc4457d177c54a44614661c7458bb0bd91b108e32"
 dependencies = [
  "bon",
  "caseless",
  "clap",
  "emojis",
  "entities",
+ "finl_unicode",
  "fmt2io",
  "jetscii",
  "phf",
@@ -239,8 +227,15 @@ dependencies = [
  "smallvec",
  "syntect",
  "typed-arena",
- "unicode_categories",
  "xdg",
+]
+
+[[package]]
+name = "comrak-ext"
+version = "0.1.6"
+dependencies = [
+ "comrak",
+ "pyo3",
 ]
 
 [[package]]
@@ -254,9 +249,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -264,11 +259,10 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -278,9 +272,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
@@ -289,9 +283,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.0"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
 ]
@@ -319,22 +313,23 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "fancy-regex"
-version = "0.11.0"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
 dependencies = [
  "bit-set",
- "regex",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -344,10 +339,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
-name = "flate2"
-version = "1.1.2"
+name = "find-msvc-tools"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -367,9 +374,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heck"
@@ -385,9 +392,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
-version = "2.11.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -395,21 +402,24 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "2.0.6"
+version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jetscii"
@@ -419,9 +429,9 @@ checksum = "47f142fe24a9c9944451e8349de0a56af5f3e7226dc46f3ed4d4ecc0b85af75e"
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "linked-hash-map"
@@ -431,15 +441,15 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memoffset"
@@ -457,13 +467,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "once_cell"
@@ -473,9 +484,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "once_cell_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "onig"
@@ -483,7 +494,7 @@ version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags",
  "libc",
  "once_cell",
  "onig_sys",
@@ -546,9 +557,9 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plist"
-version = "1.7.4"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3af6b589e163c5a788fab00ce0c0366f6efbb9959c2f9874b224936af7fce7e1"
+checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64",
  "indexmap",
@@ -559,9 +570,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "powerfmt"
@@ -581,9 +592,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.101"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -651,39 +662,27 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.3"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a232e7487fc2ef313d96dde7948e7a3c05101870d8985e4fd8d26aedd27b89"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
-name = "regex"
-version = "1.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
 name = "regex-automata"
-version = "0.4.10"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -692,9 +691,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.6"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustc-hash"
@@ -704,15 +703,15 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
-version = "1.0.8"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -720,12 +719,6 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "ryu"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -738,18 +731,27 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -758,21 +760,22 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.143"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
 name = "shell-words"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -781,10 +784,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "siphasher"
-version = "1.0.1"
+name = "simd-adler32"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "smallvec"
@@ -800,9 +809,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.106"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -811,12 +820,11 @@ dependencies = [
 
 [[package]]
 name = "syntect"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874dcfa363995604333cf947ae9f751ca3af4522c60886774c4963943b4746b1"
+checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
 dependencies = [
  "bincode",
- "bitflags 1.3.2",
  "fancy-regex",
  "flate2",
  "fnv",
@@ -834,9 +842,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.13.2"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "terminal_size"
@@ -845,23 +853,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
 dependencies = [
  "rustix",
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -870,30 +878,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.41"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.4"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.22"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -922,24 +930,18 @@ checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode_categories"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "unindent"
@@ -965,18 +967,18 @@ dependencies = [
 
 [[package]]
 name = "winapi-util"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
@@ -988,10 +990,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.53.3"
+name = "windows-sys"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
  "windows_aarch64_gnullvm",
@@ -1006,51 +1017,51 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "xdg"
@@ -1066,3 +1077,9 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [dependencies]
-comrak_lib = {package = "comrak", version = "0.50.0", features = ["shortcodes", "phoenix_heex"]}
+comrak = { version = "0.51.0", features = ["shortcodes", "phoenix_heex"] }
 pyo3 = "0.27.2"
 
 [lib]
@@ -7,7 +7,7 @@ name = "comrak"
 crate-type = ["cdylib"]
 
 [package]
-name = "comrak"
+name = "comrak-ext"
 version = "0.1.6"
 edition = "2021"
 

--- a/README.md
+++ b/README.md
@@ -27,50 +27,9 @@ Fast Markdown parser implemented in Rust, shipped for Python via PyO3.
 
 ## API
 
-### `markdown_to_html`
+### Parsing
 
-Render Markdown to HTML:
-
-```python
-from comrak import ExtensionOptions, markdown_to_html
-extension_options = ExtensionOptions()
-markdown_to_html("foo :smile:", extension_options)
-# '<p>foo :smile:</p>\n'
-
-extension_options.shortcodes = True
-markdown_to_html("foo :smile:", extension_options)
-# '<p>foo 😄</p>\n'
-```
-
-### `markdown_to_commonmark`
-
-Render Markdown to CommonMark:
-
-```python
-from comrak import RenderOptions, ListStyleType, markdown_to_commonmark
-
-render_options = RenderOptions()
-markdown_to_commonmark("- one\n- two\n- three", render_options=render_options)
-
-# '- one\n- two\n- three\n' – default is Dash
-render_options.list_style = ListStyleType.Plus
-markdown_to_commonmark("- one\n- two\n- three", render_options=render_options)
-# '+ one\n+ two\n+ three\n'
-```
-
-### `markdown_to_xml`
-
-Render Markdown to XML:
-
-```python
-from comrak import RenderOptions, markdown_to_xml
-
-render_options = RenderOptions(sourcepos=True)
-markdown_to_xml("Hello, **Markdown**!", render_options=render_options)
-# '<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE document SYSTEM "CommonMark.dtd">\n<document sourcepos="1:1-1:20" xmlns="http://commonmark.org/xml/1.0">\n  <paragraph sourcepos="1:1-1:20">\n    <text sourcepos="1:1-1:7" xml:space="preserve">Hello, </text>\n    <strong sourcepos="1:8-1:19">\n      <text sourcepos="1:10-1:17" xml:space="preserve">Markdown</text>\n    </strong>\n    <text sourcepos="1:20-1:20" xml:space="preserve">!</text>\n  </paragraph>\n</document>\n'
-```
-
-### `parse_document`
+#### `parse_document`
 
 Parse Markdown into an abstract syntax tree (AST):
 
@@ -102,20 +61,69 @@ assert isinstance(x.children[1].children[0].node_value.value, str)
 assert x.children[1].children[0].node_value.value == "Hello, Markdown!"
 ```
 
-### `format_html`
+### Rendering
 
-Format an AST back to HTML:
+#### `markdown_to_commonmark`
+
+Render Markdown to CommonMark:
 
 ```python
-from comrak import parse_document, format_html
+from comrak import RenderOptions, ListStyleType, markdown_to_commonmark
 
-p = parse_document("> Greentext blockquote requires a space after `>`")
+render_options = RenderOptions()
+markdown_to_commonmark("- one\n- two\n- three", render_options=render_options)
 
-format_html(p)
-# '<blockquote>\n<p>Greentext blockquote requires a space after <code>&gt;</code></p>\n</blockquote>\n'
+# '- one\n- two\n- three\n' – default is Dash
+render_options.list_style = ListStyleType.Plus
+markdown_to_commonmark("- one\n- two\n- three", render_options=render_options)
+# '+ one\n+ two\n+ three\n'
 ```
 
-### `format_commonmark`
+#### `markdown_to_html`
+
+Render Markdown to HTML:
+
+```python
+from comrak import ExtensionOptions, markdown_to_html
+extension_options = ExtensionOptions()
+markdown_to_html("foo :smile:", extension_options)
+# '<p>foo :smile:</p>\n'
+
+extension_options.shortcodes = True
+markdown_to_html("foo :smile:", extension_options)
+# '<p>foo 😄</p>\n'
+```
+
+#### `markdown_to_typst`
+
+Render Markdown to Typst:
+
+```python
+from comrak import ExtensionOptions, markdown_to_typst
+extension_options = ExtensionOptions()
+markdown_to_typst("foo :smile:", extension_options)
+# 'Ligature : A merged glyph.\n'
+
+extension_options.description_lists = True
+markdown_to_typst("foo :smile:", extension_options)
+# '#terms(\n  terms.item([Ligature], [A merged glyph.]),\n)\n'
+```
+
+#### `markdown_to_xml`
+
+Render Markdown to XML:
+
+```python
+from comrak import RenderOptions, markdown_to_xml
+
+render_options = RenderOptions(sourcepos=True)
+markdown_to_xml("Hello, **Markdown**!", render_options=render_options)
+# '<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE document SYSTEM "CommonMark.dtd">\n<document sourcepos="1:1-1:20" xmlns="http://commonmark.org/xml/1.0">\n  <paragraph sourcepos="1:1-1:20">\n    <text sourcepos="1:1-1:7" xml:space="preserve">Hello, </text>\n    <strong sourcepos="1:8-1:19">\n      <text sourcepos="1:10-1:17" xml:space="preserve">Markdown</text>\n    </strong>\n    <text sourcepos="1:20-1:20" xml:space="preserve">!</text>\n  </paragraph>\n</document>\n'
+```
+
+### Formatting AST
+
+#### `format_commonmark`
 
 Format an AST back to CommonMark:
 
@@ -128,7 +136,33 @@ format_commonmark(p)
 # '> Greentext blockquote requires a space after `>`\n'
 ```
 
-### `format_xml`
+#### `format_html`
+
+Format an AST back to HTML:
+
+```python
+from comrak import parse_document, format_html
+
+p = parse_document("> Greentext blockquote requires a space after `>`")
+
+format_html(p)
+# '<blockquote>\n<p>Greentext blockquote requires a space after <code>&gt;</code></p>\n</blockquote>\n'
+```
+
+#### `format_typst`
+
+Format an AST back to Typst:
+
+```python
+from comrak import parse_document, format_typst
+
+p = parse_document("> Greentext blockquote requires a space after `>`")
+
+format_typst(p)
+# '#quote(block: true)[Greentext blockquote requires a space after #raw(">")]\n'
+```
+
+#### `format_xml`
 
 Format an AST back to XML:
 

--- a/comrak.pyi
+++ b/comrak.pyi
@@ -300,6 +300,9 @@ class Strikethrough(NodeValue[None]):
 class Highlight(NodeValue[None]):
     def __init__(self) -> None: ...
 
+class Insert(NodeValue[None]):
+    def __init__(self) -> None: ...
+
 class Superscript(NodeValue[None]):
     def __init__(self) -> None: ...
 
@@ -403,6 +406,7 @@ class ExtensionOptions:
     cjk_friendly_emphasis: bool
     subtext: bool
     highlight: bool
+    insert: bool
     phoenix_heex: bool
     def __init__(
         self,
@@ -431,6 +435,7 @@ class ExtensionOptions:
         cjk_friendly_emphasis: bool = False,
         subtext: bool = False,
         highlight: bool = False,
+        insert: bool = False,
         phoenix_heex: bool = False,
     ) -> None: ...
 
@@ -472,6 +477,7 @@ class RenderOptions:
     tasklist_classes: bool
     ol_width: int
     experimental_minimize_commonmark: bool
+    compact_html: bool
     def __init__(
         self,
         hardbreaks: bool = False,
@@ -490,15 +496,28 @@ class RenderOptions:
         tasklist_classes: bool = False,
         ol_width: int = 0,
         experimental_minimize_commonmark: bool = False,
+        compact_html: bool = False,
     ) -> None: ...
 
+def parse_document(
+    text: str,
+    extension_options: Optional[ExtensionOptions] = None,
+    parse_options: Optional[ParseOptions] = None,
+    render_options: Optional[RenderOptions] = None,
+) -> AstNode: ...
+def markdown_to_commonmark(
+    text: str,
+    extension_options: Optional[ExtensionOptions] = None,
+    parse_options: Optional[ParseOptions] = None,
+    render_options: Optional[RenderOptions] = None,
+) -> str: ...
 def markdown_to_html(
     text: str,
     extension_options: Optional[ExtensionOptions] = None,
     parse_options: Optional[ParseOptions] = None,
     render_options: Optional[RenderOptions] = None,
 ) -> str: ...
-def markdown_to_commonmark(
+def markdown_to_typst(
     text: str,
     extension_options: Optional[ExtensionOptions] = None,
     parse_options: Optional[ParseOptions] = None,
@@ -510,19 +529,19 @@ def markdown_to_xml(
     parse_options: Optional[ParseOptions] = None,
     render_options: Optional[RenderOptions] = None,
 ) -> str: ...
-def parse_document(
-    text: str,
+def format_commonmark(
+    node: AstNode,
     extension_options: Optional[ExtensionOptions] = None,
     parse_options: Optional[ParseOptions] = None,
     render_options: Optional[RenderOptions] = None,
-) -> AstNode: ...
+) -> str: ...
 def format_html(
     node: AstNode,
     extension_options: Optional[ExtensionOptions] = None,
     parse_options: Optional[ParseOptions] = None,
     render_options: Optional[RenderOptions] = None,
 ) -> str: ...
-def format_commonmark(
+def format_typst(
     node: AstNode,
     extension_options: Optional[ExtensionOptions] = None,
     parse_options: Optional[ParseOptions] = None,

--- a/src/astnode.rs
+++ b/src/astnode.rs
@@ -1,4 +1,4 @@
-use comrak_lib::nodes::*;
+use comrak::nodes::*;
 use pyo3::{prelude::*, pyclass, IntoPyObjectExt};
 
 #[pyclass(name = "LineColumn", get_all, set_all, eq)]
@@ -1223,6 +1223,18 @@ impl PyHighlight {
     }
 }
 
+#[pyclass(name = "Insert", extends=PyNodeValue, eq)]
+#[derive(PartialEq, Eq)]
+pub struct PyInsert {}
+
+#[pymethods]
+impl PyInsert {
+    #[new]
+    pub fn new() -> (Self, PyNodeValue) {
+        (Self {}, PyNodeValue::new())
+    }
+}
+
 #[pyclass(name = "Superscript", extends=PyNodeValue, eq)]
 #[derive(PartialEq, Eq)]
 pub struct PySuperscript {}
@@ -1448,28 +1460,28 @@ impl PyAstNode {
     }
 }
 
-fn create_py_node_value(py: Python, value: &comrak_lib::nodes::NodeValue) -> Py<PyAny> {
+fn create_py_node_value(py: Python, value: &comrak::nodes::NodeValue) -> Py<PyAny> {
     match value {
-        comrak_lib::nodes::NodeValue::Document => Py::new(
+        comrak::nodes::NodeValue::Document => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {}).add_subclass(PyDocument {}),
         )
         .unwrap()
         .into(),
-        comrak_lib::nodes::NodeValue::FrontMatter(s) => Py::new(
+        comrak::nodes::NodeValue::FrontMatter(s) => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {})
                 .add_subclass(PyFrontMatter { value: s.clone() }),
         )
         .unwrap()
         .into(),
-        comrak_lib::nodes::NodeValue::BlockQuote => Py::new(
+        comrak::nodes::NodeValue::BlockQuote => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {}).add_subclass(PyBlockQuote {}),
         )
         .unwrap()
         .into(),
-        comrak_lib::nodes::NodeValue::List(l) => Py::new(
+        comrak::nodes::NodeValue::List(l) => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {}).add_subclass(PyList {
                 value: PyNodeList::from(l),
@@ -1477,7 +1489,7 @@ fn create_py_node_value(py: Python, value: &comrak_lib::nodes::NodeValue) -> Py<
         )
         .unwrap()
         .into(),
-        comrak_lib::nodes::NodeValue::Item(i) => Py::new(
+        comrak::nodes::NodeValue::Item(i) => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {}).add_subclass(PyItem {
                 value: PyNodeList::from(i),
@@ -1485,13 +1497,13 @@ fn create_py_node_value(py: Python, value: &comrak_lib::nodes::NodeValue) -> Py<
         )
         .unwrap()
         .into(),
-        comrak_lib::nodes::NodeValue::DescriptionList => Py::new(
+        comrak::nodes::NodeValue::DescriptionList => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {}).add_subclass(PyDescriptionList {}),
         )
         .unwrap()
         .into(),
-        comrak_lib::nodes::NodeValue::DescriptionItem(d) => Py::new(
+        comrak::nodes::NodeValue::DescriptionItem(d) => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {}).add_subclass(PyDescriptionItem {
                 value: PyNodeDescriptionItem::from(d),
@@ -1499,19 +1511,19 @@ fn create_py_node_value(py: Python, value: &comrak_lib::nodes::NodeValue) -> Py<
         )
         .unwrap()
         .into(),
-        comrak_lib::nodes::NodeValue::DescriptionTerm => Py::new(
+        comrak::nodes::NodeValue::DescriptionTerm => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {}).add_subclass(PyDescriptionTerm {}),
         )
         .unwrap()
         .into(),
-        comrak_lib::nodes::NodeValue::DescriptionDetails => Py::new(
+        comrak::nodes::NodeValue::DescriptionDetails => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {}).add_subclass(PyDescriptionDetails {}),
         )
         .unwrap()
         .into(),
-        comrak_lib::nodes::NodeValue::CodeBlock(c) => Py::new(
+        comrak::nodes::NodeValue::CodeBlock(c) => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {}).add_subclass(PyCodeBlock {
                 value: PyNodeCodeBlock::from(c.as_ref()),
@@ -1519,7 +1531,7 @@ fn create_py_node_value(py: Python, value: &comrak_lib::nodes::NodeValue) -> Py<
         )
         .unwrap()
         .into(),
-        comrak_lib::nodes::NodeValue::HtmlBlock(h) => Py::new(
+        comrak::nodes::NodeValue::HtmlBlock(h) => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {}).add_subclass(PyHtmlBlock {
                 value: PyNodeHtmlBlock::from(h),
@@ -1527,7 +1539,7 @@ fn create_py_node_value(py: Python, value: &comrak_lib::nodes::NodeValue) -> Py<
         )
         .unwrap()
         .into(),
-        comrak_lib::nodes::NodeValue::HeexBlock(h) => Py::new(
+        comrak::nodes::NodeValue::HeexBlock(h) => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {}).add_subclass(PyHeexBlock {
                 value: PyNodeHeexBlock::from((py, h.as_ref())),
@@ -1535,13 +1547,13 @@ fn create_py_node_value(py: Python, value: &comrak_lib::nodes::NodeValue) -> Py<
         )
         .unwrap()
         .into(),
-        comrak_lib::nodes::NodeValue::Paragraph => Py::new(
+        comrak::nodes::NodeValue::Paragraph => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {}).add_subclass(PyParagraph {}),
         )
         .unwrap()
         .into(),
-        comrak_lib::nodes::NodeValue::Heading(h) => Py::new(
+        comrak::nodes::NodeValue::Heading(h) => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {}).add_subclass(PyHeading {
                 value: PyNodeHeading::from(h),
@@ -1549,13 +1561,13 @@ fn create_py_node_value(py: Python, value: &comrak_lib::nodes::NodeValue) -> Py<
         )
         .unwrap()
         .into(),
-        comrak_lib::nodes::NodeValue::ThematicBreak => Py::new(
+        comrak::nodes::NodeValue::ThematicBreak => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {}).add_subclass(PyThematicBreak {}),
         )
         .unwrap()
         .into(),
-        comrak_lib::nodes::NodeValue::FootnoteDefinition(f) => Py::new(
+        comrak::nodes::NodeValue::FootnoteDefinition(f) => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {}).add_subclass(PyFootnoteDefinition {
                 value: PyNodeFootnoteDefinition::from(f),
@@ -1563,7 +1575,7 @@ fn create_py_node_value(py: Python, value: &comrak_lib::nodes::NodeValue) -> Py<
         )
         .unwrap()
         .into(),
-        comrak_lib::nodes::NodeValue::Table(t) => Py::new(
+        comrak::nodes::NodeValue::Table(t) => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {}).add_subclass(PyTable {
                 value: PyNodeTable::from(t.as_ref()),
@@ -1571,19 +1583,19 @@ fn create_py_node_value(py: Python, value: &comrak_lib::nodes::NodeValue) -> Py<
         )
         .unwrap()
         .into(),
-        comrak_lib::nodes::NodeValue::TableRow(is_header) => Py::new(
+        comrak::nodes::NodeValue::TableRow(is_header) => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {}).add_subclass(PyTableRow { value: *is_header }),
         )
         .unwrap()
         .into(),
-        comrak_lib::nodes::NodeValue::TableCell => Py::new(
+        comrak::nodes::NodeValue::TableCell => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {}).add_subclass(PyTableCell {}),
         )
         .unwrap()
         .into(),
-        comrak_lib::nodes::NodeValue::Text(t) => Py::new(
+        comrak::nodes::NodeValue::Text(t) => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {}).add_subclass(PyText {
                 value: t.to_string(),
@@ -1591,7 +1603,7 @@ fn create_py_node_value(py: Python, value: &comrak_lib::nodes::NodeValue) -> Py<
         )
         .unwrap()
         .into(),
-        comrak_lib::nodes::NodeValue::TaskItem(c) => Py::new(
+        comrak::nodes::NodeValue::TaskItem(c) => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {}).add_subclass(PyTaskItem {
                 value: PyNodeTaskItem::from(c),
@@ -1599,19 +1611,19 @@ fn create_py_node_value(py: Python, value: &comrak_lib::nodes::NodeValue) -> Py<
         )
         .unwrap()
         .into(),
-        comrak_lib::nodes::NodeValue::SoftBreak => Py::new(
+        comrak::nodes::NodeValue::SoftBreak => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {}).add_subclass(PySoftBreak {}),
         )
         .unwrap()
         .into(),
-        comrak_lib::nodes::NodeValue::LineBreak => Py::new(
+        comrak::nodes::NodeValue::LineBreak => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {}).add_subclass(PyLineBreak {}),
         )
         .unwrap()
         .into(),
-        comrak_lib::nodes::NodeValue::Code(c) => Py::new(
+        comrak::nodes::NodeValue::Code(c) => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {}).add_subclass(PyCode {
                 value: PyNodeCode::from(c),
@@ -1619,57 +1631,63 @@ fn create_py_node_value(py: Python, value: &comrak_lib::nodes::NodeValue) -> Py<
         )
         .unwrap()
         .into(),
-        comrak_lib::nodes::NodeValue::HtmlInline(s) => Py::new(
+        comrak::nodes::NodeValue::HtmlInline(s) => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {})
                 .add_subclass(PyHtmlInline { value: s.clone() }),
         )
         .unwrap()
         .into(),
-        comrak_lib::nodes::NodeValue::HeexInline(s) => Py::new(
+        comrak::nodes::NodeValue::HeexInline(s) => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {})
                 .add_subclass(PyHeexInline { value: s.clone() }),
         )
         .unwrap()
         .into(),
-        comrak_lib::nodes::NodeValue::Raw(s) => Py::new(
+        comrak::nodes::NodeValue::Raw(s) => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {}).add_subclass(PyRaw { value: s.clone() }),
         )
         .unwrap()
         .into(),
-        comrak_lib::nodes::NodeValue::Emph => Py::new(
+        comrak::nodes::NodeValue::Emph => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {}).add_subclass(PyEmph {}),
         )
         .unwrap()
         .into(),
-        comrak_lib::nodes::NodeValue::Strong => Py::new(
+        comrak::nodes::NodeValue::Strong => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {}).add_subclass(PyStrong {}),
         )
         .unwrap()
         .into(),
-        comrak_lib::nodes::NodeValue::Strikethrough => Py::new(
+        comrak::nodes::NodeValue::Strikethrough => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {}).add_subclass(PyStrikethrough {}),
         )
         .unwrap()
         .into(),
-        comrak_lib::nodes::NodeValue::Highlight => Py::new(
+        comrak::nodes::NodeValue::Highlight => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {}).add_subclass(PyHighlight {}),
         )
         .unwrap()
         .into(),
-        comrak_lib::nodes::NodeValue::Superscript => Py::new(
+        comrak::nodes::NodeValue::Insert => Py::new(
+            py,
+            PyClassInitializer::from(PyNodeValue {}).add_subclass(PyInsert {}),
+        )
+        .unwrap()
+        .into(),
+        comrak::nodes::NodeValue::Superscript => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {}).add_subclass(PySuperscript {}),
         )
         .unwrap()
         .into(),
-        comrak_lib::nodes::NodeValue::Link(l) => Py::new(
+        comrak::nodes::NodeValue::Link(l) => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {}).add_subclass(PyLink {
                 value: PyNodeLink::from(l.as_ref()),
@@ -1677,7 +1695,7 @@ fn create_py_node_value(py: Python, value: &comrak_lib::nodes::NodeValue) -> Py<
         )
         .unwrap()
         .into(),
-        comrak_lib::nodes::NodeValue::Image(i) => Py::new(
+        comrak::nodes::NodeValue::Image(i) => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {}).add_subclass(PyImage {
                 value: PyNodeLink::from(i.as_ref()),
@@ -1685,7 +1703,7 @@ fn create_py_node_value(py: Python, value: &comrak_lib::nodes::NodeValue) -> Py<
         )
         .unwrap()
         .into(),
-        comrak_lib::nodes::NodeValue::FootnoteReference(f) => Py::new(
+        comrak::nodes::NodeValue::FootnoteReference(f) => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {}).add_subclass(PyFootnoteReference {
                 value: PyNodeFootnoteReference::from(f.as_ref()),
@@ -1693,7 +1711,7 @@ fn create_py_node_value(py: Python, value: &comrak_lib::nodes::NodeValue) -> Py<
         )
         .unwrap()
         .into(),
-        comrak_lib::nodes::NodeValue::ShortCode(s) => Py::new(
+        comrak::nodes::NodeValue::ShortCode(s) => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {}).add_subclass(PyShortCode {
                 value: PyNodeShortCode::from(s.as_ref()),
@@ -1701,7 +1719,7 @@ fn create_py_node_value(py: Python, value: &comrak_lib::nodes::NodeValue) -> Py<
         )
         .unwrap()
         .into(),
-        comrak_lib::nodes::NodeValue::Math(m) => Py::new(
+        comrak::nodes::NodeValue::Math(m) => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {}).add_subclass(PyMath {
                 value: PyNodeMath::from(m),
@@ -1709,7 +1727,7 @@ fn create_py_node_value(py: Python, value: &comrak_lib::nodes::NodeValue) -> Py<
         )
         .unwrap()
         .into(),
-        comrak_lib::nodes::NodeValue::MultilineBlockQuote(m) => Py::new(
+        comrak::nodes::NodeValue::MultilineBlockQuote(m) => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {}).add_subclass(PyMultilineBlockQuote {
                 value: PyNodeMultilineBlockQuote::from(m),
@@ -1717,13 +1735,13 @@ fn create_py_node_value(py: Python, value: &comrak_lib::nodes::NodeValue) -> Py<
         )
         .unwrap()
         .into(),
-        comrak_lib::nodes::NodeValue::Escaped => Py::new(
+        comrak::nodes::NodeValue::Escaped => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {}).add_subclass(PyEscaped {}),
         )
         .unwrap()
         .into(),
-        comrak_lib::nodes::NodeValue::WikiLink(w) => Py::new(
+        comrak::nodes::NodeValue::WikiLink(w) => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {}).add_subclass(PyWikiLink {
                 value: PyNodeWikiLink::from(w),
@@ -1731,25 +1749,25 @@ fn create_py_node_value(py: Python, value: &comrak_lib::nodes::NodeValue) -> Py<
         )
         .unwrap()
         .into(),
-        comrak_lib::nodes::NodeValue::Underline => Py::new(
+        comrak::nodes::NodeValue::Underline => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {}).add_subclass(PyUnderline {}),
         )
         .unwrap()
         .into(),
-        comrak_lib::nodes::NodeValue::Subscript => Py::new(
+        comrak::nodes::NodeValue::Subscript => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {}).add_subclass(PySubscript {}),
         )
         .unwrap()
         .into(),
-        comrak_lib::nodes::NodeValue::SpoileredText => Py::new(
+        comrak::nodes::NodeValue::SpoileredText => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {}).add_subclass(PySpoileredText {}),
         )
         .unwrap()
         .into(),
-        comrak_lib::nodes::NodeValue::EscapedTag(s) => Py::new(
+        comrak::nodes::NodeValue::EscapedTag(s) => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {}).add_subclass(PyEscapedTag {
                 value: s.to_string(),
@@ -1757,7 +1775,7 @@ fn create_py_node_value(py: Python, value: &comrak_lib::nodes::NodeValue) -> Py<
         )
         .unwrap()
         .into(),
-        comrak_lib::nodes::NodeValue::Alert(a) => Py::new(
+        comrak::nodes::NodeValue::Alert(a) => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {}).add_subclass(PyAlert {
                 value: PyNodeAlert::from(a.as_ref()),
@@ -1765,7 +1783,7 @@ fn create_py_node_value(py: Python, value: &comrak_lib::nodes::NodeValue) -> Py<
         )
         .unwrap()
         .into(),
-        comrak_lib::nodes::NodeValue::Subtext => Py::new(
+        comrak::nodes::NodeValue::Subtext => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {}).add_subclass(PySubtext {}),
         )
@@ -1790,20 +1808,20 @@ fn py_sourcepos_to_sourcepos(sp: &PySourcepos) -> Sourcepos {
 fn create_comrak_node_value<'a>(
     py: Python<'a>,
     node_value: &Py<PyAny>,
-) -> comrak_lib::nodes::NodeValue {
+) -> comrak::nodes::NodeValue {
     let any = node_value.as_ref();
 
     // Try each concrete Python subclass in turn and build the matching NodeValue
     if let Ok(_v) = any.extract::<pyo3::PyRef<PyDocument>>(py) {
-        return comrak_lib::nodes::NodeValue::Document;
+        return comrak::nodes::NodeValue::Document;
     }
 
     if let Ok(v) = any.extract::<pyo3::PyRef<PyFrontMatter>>(py) {
-        return comrak_lib::nodes::NodeValue::FrontMatter(v.value.clone());
+        return comrak::nodes::NodeValue::FrontMatter(v.value.clone());
     }
 
     if let Ok(_v) = any.extract::<pyo3::PyRef<PyBlockQuote>>(py) {
-        return comrak_lib::nodes::NodeValue::BlockQuote;
+        return comrak::nodes::NodeValue::BlockQuote;
     }
 
     if let Ok(v) = any.extract::<pyo3::PyRef<PyList>>(py) {
@@ -1817,7 +1835,7 @@ fn create_comrak_node_value<'a>(
             PyListDelimType::Paren => ListDelimType::Paren,
         };
 
-        return comrak_lib::nodes::NodeValue::List(NodeList {
+        return comrak::nodes::NodeValue::List(NodeList {
             list_type,
             marker_offset: pl.marker_offset,
             padding: pl.padding,
@@ -1840,7 +1858,7 @@ fn create_comrak_node_value<'a>(
             PyListDelimType::Paren => ListDelimType::Paren,
         };
 
-        return comrak_lib::nodes::NodeValue::Item(NodeList {
+        return comrak::nodes::NodeValue::Item(NodeList {
             list_type,
             marker_offset: pl.marker_offset,
             padding: pl.padding,
@@ -1853,12 +1871,12 @@ fn create_comrak_node_value<'a>(
     }
 
     if let Ok(_v) = any.extract::<pyo3::PyRef<PyDescriptionList>>(py) {
-        return comrak_lib::nodes::NodeValue::DescriptionList;
+        return comrak::nodes::NodeValue::DescriptionList;
     }
 
     if let Ok(v) = any.extract::<pyo3::PyRef<PyDescriptionItem>>(py) {
         let di = &v.value;
-        return comrak_lib::nodes::NodeValue::DescriptionItem(NodeDescriptionItem {
+        return comrak::nodes::NodeValue::DescriptionItem(NodeDescriptionItem {
             marker_offset: di.marker_offset,
             padding: di.padding,
             tight: di.tight,
@@ -1866,16 +1884,16 @@ fn create_comrak_node_value<'a>(
     }
 
     if let Ok(_v) = any.extract::<pyo3::PyRef<PyDescriptionTerm>>(py) {
-        return comrak_lib::nodes::NodeValue::DescriptionTerm;
+        return comrak::nodes::NodeValue::DescriptionTerm;
     }
 
     if let Ok(_v) = any.extract::<pyo3::PyRef<PyDescriptionDetails>>(py) {
-        return comrak_lib::nodes::NodeValue::DescriptionDetails;
+        return comrak::nodes::NodeValue::DescriptionDetails;
     }
 
     if let Ok(v) = any.extract::<pyo3::PyRef<PyCodeBlock>>(py) {
         let cb = &v.value;
-        return comrak_lib::nodes::NodeValue::CodeBlock(Box::new(NodeCodeBlock {
+        return comrak::nodes::NodeValue::CodeBlock(Box::new(NodeCodeBlock {
             fenced: cb.fenced,
             fence_char: cb.fence_char,
             fence_length: cb.fence_length,
@@ -1888,7 +1906,7 @@ fn create_comrak_node_value<'a>(
 
     if let Ok(v) = any.extract::<pyo3::PyRef<PyHtmlBlock>>(py) {
         let hb = &v.value;
-        return comrak_lib::nodes::NodeValue::HtmlBlock(NodeHtmlBlock {
+        return comrak::nodes::NodeValue::HtmlBlock(NodeHtmlBlock {
             block_type: hb.block_type,
             literal: hb.literal.clone(),
         });
@@ -1899,31 +1917,31 @@ fn create_comrak_node_value<'a>(
         // Convert HeexNode Py<PyAny> -> HeexNode
         let py_node_any = hb.node.as_ref();
         if let Ok(_) = py_node_any.extract::<pyo3::PyRef<PyHeexNodeDirective>>(py) {
-            return comrak_lib::nodes::NodeValue::HeexBlock(Box::new(NodeHeexBlock {
+            return comrak::nodes::NodeValue::HeexBlock(Box::new(NodeHeexBlock {
                 literal: hb.literal.clone(),
                 node: HeexNode::Directive,
             }));
         }
         if let Ok(_) = py_node_any.extract::<pyo3::PyRef<PyHeexNodeComment>>(py) {
-            return comrak_lib::nodes::NodeValue::HeexBlock(Box::new(NodeHeexBlock {
+            return comrak::nodes::NodeValue::HeexBlock(Box::new(NodeHeexBlock {
                 literal: hb.literal.clone(),
                 node: HeexNode::Comment,
             }));
         }
         if let Ok(_) = py_node_any.extract::<pyo3::PyRef<PyHeexNodeMultilineComment>>(py) {
-            return comrak_lib::nodes::NodeValue::HeexBlock(Box::new(NodeHeexBlock {
+            return comrak::nodes::NodeValue::HeexBlock(Box::new(NodeHeexBlock {
                 literal: hb.literal.clone(),
                 node: HeexNode::MultilineComment,
             }));
         }
         if let Ok(_) = py_node_any.extract::<pyo3::PyRef<PyHeexNodeExpression>>(py) {
-            return comrak_lib::nodes::NodeValue::HeexBlock(Box::new(NodeHeexBlock {
+            return comrak::nodes::NodeValue::HeexBlock(Box::new(NodeHeexBlock {
                 literal: hb.literal.clone(),
                 node: HeexNode::Expression,
             }));
         }
         if let Ok(tag) = py_node_any.extract::<pyo3::PyRef<PyHeexNodeTag>>(py) {
-            return comrak_lib::nodes::NodeValue::HeexBlock(Box::new(NodeHeexBlock {
+            return comrak::nodes::NodeValue::HeexBlock(Box::new(NodeHeexBlock {
                 literal: hb.literal.clone(),
                 node: HeexNode::Tag(tag.tag.clone()),
             }));
@@ -1931,12 +1949,12 @@ fn create_comrak_node_value<'a>(
     }
 
     if let Ok(_v) = any.extract::<pyo3::PyRef<PyParagraph>>(py) {
-        return comrak_lib::nodes::NodeValue::Paragraph;
+        return comrak::nodes::NodeValue::Paragraph;
     }
 
     if let Ok(v) = any.extract::<pyo3::PyRef<PyHeading>>(py) {
         let h = &v.value;
-        return comrak_lib::nodes::NodeValue::Heading(NodeHeading {
+        return comrak::nodes::NodeValue::Heading(NodeHeading {
             level: h.level,
             setext: h.setext,
             closed: h.closed,
@@ -1944,12 +1962,12 @@ fn create_comrak_node_value<'a>(
     }
 
     if let Ok(_v) = any.extract::<pyo3::PyRef<PyThematicBreak>>(py) {
-        return comrak_lib::nodes::NodeValue::ThematicBreak;
+        return comrak::nodes::NodeValue::ThematicBreak;
     }
 
     if let Ok(v) = any.extract::<pyo3::PyRef<PyFootnoteDefinition>>(py) {
         let f = &v.value;
-        return comrak_lib::nodes::NodeValue::FootnoteDefinition(NodeFootnoteDefinition {
+        return comrak::nodes::NodeValue::FootnoteDefinition(NodeFootnoteDefinition {
             name: f.name.clone(),
             total_references: f.total_references,
         });
@@ -1968,7 +1986,7 @@ fn create_comrak_node_value<'a>(
             })
             .collect();
 
-        return comrak_lib::nodes::NodeValue::Table(Box::new(NodeTable {
+        return comrak::nodes::NodeValue::Table(Box::new(NodeTable {
             alignments,
             num_columns: t.num_columns,
             num_rows: t.num_rows,
@@ -1977,82 +1995,86 @@ fn create_comrak_node_value<'a>(
     }
 
     if let Ok(v) = any.extract::<pyo3::PyRef<PyTableRow>>(py) {
-        return comrak_lib::nodes::NodeValue::TableRow(v.value);
+        return comrak::nodes::NodeValue::TableRow(v.value);
     }
 
     if let Ok(_v) = any.extract::<pyo3::PyRef<PyTableCell>>(py) {
-        return comrak_lib::nodes::NodeValue::TableCell;
+        return comrak::nodes::NodeValue::TableCell;
     }
 
     if let Ok(v) = any.extract::<pyo3::PyRef<PyText>>(py) {
-        return comrak_lib::nodes::NodeValue::Text(v.value.clone().into());
+        return comrak::nodes::NodeValue::Text(v.value.clone().into());
     }
 
     if let Ok(v) = any.extract::<pyo3::PyRef<PyTaskItem>>(py) {
         let ti = &v.value;
-        return comrak_lib::nodes::NodeValue::TaskItem(NodeTaskItem {
+        return comrak::nodes::NodeValue::TaskItem(NodeTaskItem {
             symbol: ti.symbol,
             symbol_sourcepos: py_sourcepos_to_sourcepos(&ti.symbol_sourcepos),
         });
     }
 
     if let Ok(_v) = any.extract::<pyo3::PyRef<PySoftBreak>>(py) {
-        return comrak_lib::nodes::NodeValue::SoftBreak;
+        return comrak::nodes::NodeValue::SoftBreak;
     }
 
     if let Ok(_v) = any.extract::<pyo3::PyRef<PyLineBreak>>(py) {
-        return comrak_lib::nodes::NodeValue::LineBreak;
+        return comrak::nodes::NodeValue::LineBreak;
     }
 
     if let Ok(v) = any.extract::<pyo3::PyRef<PyCode>>(py) {
         let c = &v.value;
-        return comrak_lib::nodes::NodeValue::Code(NodeCode {
+        return comrak::nodes::NodeValue::Code(NodeCode {
             num_backticks: c.num_backticks,
             literal: c.literal.clone(),
         });
     }
 
     if let Ok(v) = any.extract::<pyo3::PyRef<PyHtmlInline>>(py) {
-        return comrak_lib::nodes::NodeValue::HtmlInline(v.value.clone());
+        return comrak::nodes::NodeValue::HtmlInline(v.value.clone());
     }
 
     if let Ok(v) = any.extract::<pyo3::PyRef<PyHeexInline>>(py) {
-        return comrak_lib::nodes::NodeValue::HeexInline(v.value.clone());
+        return comrak::nodes::NodeValue::HeexInline(v.value.clone());
     }
 
     if let Ok(v) = any.extract::<pyo3::PyRef<PyRaw>>(py) {
-        return comrak_lib::nodes::NodeValue::Raw(v.value.clone());
+        return comrak::nodes::NodeValue::Raw(v.value.clone());
     }
 
     if let Ok(_v) = any.extract::<pyo3::PyRef<PyEmph>>(py) {
-        return comrak_lib::nodes::NodeValue::Emph;
+        return comrak::nodes::NodeValue::Emph;
     }
 
     if let Ok(_v) = any.extract::<pyo3::PyRef<PyStrong>>(py) {
-        return comrak_lib::nodes::NodeValue::Strong;
+        return comrak::nodes::NodeValue::Strong;
     }
 
     if let Ok(_v) = any.extract::<pyo3::PyRef<PyStrikethrough>>(py) {
-        return comrak_lib::nodes::NodeValue::Strikethrough;
+        return comrak::nodes::NodeValue::Strikethrough;
     }
 
     if let Ok(_v) = any.extract::<pyo3::PyRef<PyHighlight>>(py) {
-        return comrak_lib::nodes::NodeValue::Highlight;
+        return comrak::nodes::NodeValue::Highlight;
+    }
+
+    if let Ok(_v) = any.extract::<pyo3::PyRef<PyInsert>>(py) {
+        return comrak::nodes::NodeValue::Insert;
     }
 
     if let Ok(_v) = any.extract::<pyo3::PyRef<PySuperscript>>(py) {
-        return comrak_lib::nodes::NodeValue::Superscript;
+        return comrak::nodes::NodeValue::Superscript;
     }
 
     if let Ok(v) = any.extract::<pyo3::PyRef<PyLink>>(py) {
-        return comrak_lib::nodes::NodeValue::Link(Box::new(NodeLink {
+        return comrak::nodes::NodeValue::Link(Box::new(NodeLink {
             url: v.value.url.clone(),
             title: v.value.title.clone(),
         }));
     }
 
     if let Ok(v) = any.extract::<pyo3::PyRef<PyImage>>(py) {
-        return comrak_lib::nodes::NodeValue::Image(Box::new(NodeLink {
+        return comrak::nodes::NodeValue::Image(Box::new(NodeLink {
             url: v.value.url.clone(),
             title: v.value.title.clone(),
         }));
@@ -2060,7 +2082,7 @@ fn create_comrak_node_value<'a>(
 
     if let Ok(v) = any.extract::<pyo3::PyRef<PyFootnoteReference>>(py) {
         let fr = &v.value;
-        return comrak_lib::nodes::NodeValue::FootnoteReference(Box::new(NodeFootnoteReference {
+        return comrak::nodes::NodeValue::FootnoteReference(Box::new(NodeFootnoteReference {
             name: fr.name.clone(),
             texts: fr.texts.clone(),
             ref_num: fr.ref_num,
@@ -2069,14 +2091,14 @@ fn create_comrak_node_value<'a>(
     }
 
     if let Ok(v) = any.extract::<pyo3::PyRef<PyShortCode>>(py) {
-        return comrak_lib::nodes::NodeValue::ShortCode(Box::new(NodeShortCode {
+        return comrak::nodes::NodeValue::ShortCode(Box::new(NodeShortCode {
             code: v.value.code.clone(),
             emoji: v.value.emoji.clone(),
         }));
     }
 
     if let Ok(v) = any.extract::<pyo3::PyRef<PyMath>>(py) {
-        return comrak_lib::nodes::NodeValue::Math(NodeMath {
+        return comrak::nodes::NodeValue::Math(NodeMath {
             dollar_math: v.value.dollar_math,
             display_math: v.value.display_math,
             literal: v.value.literal.clone(),
@@ -2084,38 +2106,36 @@ fn create_comrak_node_value<'a>(
     }
 
     if let Ok(v) = any.extract::<pyo3::PyRef<PyMultilineBlockQuote>>(py) {
-        return comrak_lib::nodes::NodeValue::MultilineBlockQuote(NodeMultilineBlockQuote {
+        return comrak::nodes::NodeValue::MultilineBlockQuote(NodeMultilineBlockQuote {
             fence_length: v.value.fence_length,
             fence_offset: v.value.fence_offset,
         });
     }
 
     if let Ok(_v) = any.extract::<pyo3::PyRef<PyEscaped>>(py) {
-        return comrak_lib::nodes::NodeValue::Escaped;
+        return comrak::nodes::NodeValue::Escaped;
     }
 
     if let Ok(v) = any.extract::<pyo3::PyRef<PyWikiLink>>(py) {
-        return comrak_lib::nodes::NodeValue::WikiLink(NodeWikiLink {
+        return comrak::nodes::NodeValue::WikiLink(NodeWikiLink {
             url: v.value.url.clone(),
         });
     }
 
     if let Ok(_v) = any.extract::<pyo3::PyRef<PyUnderline>>(py) {
-        return comrak_lib::nodes::NodeValue::Underline;
+        return comrak::nodes::NodeValue::Underline;
     }
 
     if let Ok(_v) = any.extract::<pyo3::PyRef<PySubscript>>(py) {
-        return comrak_lib::nodes::NodeValue::Subscript;
+        return comrak::nodes::NodeValue::Subscript;
     }
 
     if let Ok(_v) = any.extract::<pyo3::PyRef<PySpoileredText>>(py) {
-        return comrak_lib::nodes::NodeValue::SpoileredText;
+        return comrak::nodes::NodeValue::SpoileredText;
     }
 
     if let Ok(v) = any.extract::<pyo3::PyRef<PyEscapedTag>>(py) {
-        return comrak_lib::nodes::NodeValue::EscapedTag(Box::leak(
-            v.value.clone().into_boxed_str(),
-        ));
+        return comrak::nodes::NodeValue::EscapedTag(Box::leak(v.value.clone().into_boxed_str()));
     }
 
     if let Ok(v) = any.extract::<pyo3::PyRef<PyAlert>>(py) {
@@ -2128,7 +2148,7 @@ fn create_comrak_node_value<'a>(
             PyAlertType::Caution => AlertType::Caution,
         };
 
-        return comrak_lib::nodes::NodeValue::Alert(Box::new(NodeAlert {
+        return comrak::nodes::NodeValue::Alert(Box::new(NodeAlert {
             alert_type,
             title: a.title.clone(),
             multiline: a.multiline,
@@ -2138,11 +2158,11 @@ fn create_comrak_node_value<'a>(
     }
 
     if let Ok(_v) = any.extract::<pyo3::PyRef<PySubtext>>(py) {
-        return comrak_lib::nodes::NodeValue::Subtext;
+        return comrak::nodes::NodeValue::Subtext;
     }
 
     // Fallback: default to Document if unknown
-    comrak_lib::nodes::NodeValue::Document
+    comrak::nodes::NodeValue::Document
 }
 
 impl PyAstNode {
@@ -2180,13 +2200,13 @@ impl PyAstNode {
     pub fn to_comrak_node<'a>(
         &self,
         py: Python<'a>,
-        arena: &'a comrak_lib::Arena<'a>,
-    ) -> &'a comrak_lib::nodes::AstNode<'a> {
+        arena: &'a comrak::Arena<'a>,
+    ) -> &'a comrak::nodes::AstNode<'a> {
         let node_value = self.node_value.as_ref();
         let ast_node_value = create_comrak_node_value(py, node_value);
 
         let node_in_arena = arena.alloc(
-            comrak_lib::nodes::Ast::new_with_sourcepos(
+            comrak::nodes::Ast::new_with_sourcepos(
                 ast_node_value,
                 py_sourcepos_to_sourcepos(&self.sourcepos),
             )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
 use pyo3::prelude::*;
 
-// We renamed the Rust library to `comrak_lib`
-use comrak_lib::{
-    format_commonmark, format_html, format_xml, markdown_to_commonmark, markdown_to_commonmark_xml,
-    markdown_to_html, parse_document, Arena, Options as ComrakOptions,
+use ::comrak::{
+    format_commonmark, format_html, format_typst, format_xml, markdown_to_commonmark,
+    markdown_to_commonmark_xml, markdown_to_html, markdown_to_typst, parse_document, Arena,
+    Options as ComrakOptions,
 };
 
 // Import the Python option classes we defined
@@ -26,87 +26,7 @@ use astnode::{
     PyText, PyThematicBreak, PyUnderline, PyWikiLink,
 };
 
-/// Render a Markdown string to HTML, with optional Extension/Parse/Render overrides.
-#[pyfunction(name = "markdown_to_html", signature=(text, extension_options=None, parse_options=None, render_options=None))]
-fn render_markdown(
-    text: &str,
-    extension_options: Option<PyExtensionOptions>,
-    parse_options: Option<PyParseOptions>,
-    render_options: Option<PyRenderOptions>,
-) -> PyResult<String> {
-    let mut opts = ComrakOptions::default();
-
-    // If user provided custom extension options, apply them.
-    if let Some(py_ext) = extension_options {
-        py_ext.update_extension_options(&mut opts.extension);
-    }
-
-    if let Some(py_parse) = parse_options {
-        py_parse.update_parse_options(&mut opts.parse);
-    }
-
-    if let Some(py_render) = render_options {
-        py_render.update_render_options(&mut opts.render);
-    }
-
-    let html = markdown_to_html(text, &opts);
-    Ok(html)
-}
-
-/// Convert a Markdown string to CommonMark format.
-#[pyfunction(name = "markdown_to_commonmark", signature=(text, extension_options=None, parse_options=None, render_options=None))]
-fn render_markdown_to_commonmark(
-    text: &str,
-    extension_options: Option<PyExtensionOptions>,
-    parse_options: Option<PyParseOptions>,
-    render_options: Option<PyRenderOptions>,
-) -> PyResult<String> {
-    let mut opts = ComrakOptions::default();
-
-    // If user provided custom extension options, apply them.
-    if let Some(py_ext) = extension_options {
-        py_ext.update_extension_options(&mut opts.extension);
-    }
-
-    if let Some(py_parse) = parse_options {
-        py_parse.update_parse_options(&mut opts.parse);
-    }
-
-    if let Some(py_render) = render_options {
-        py_render.update_render_options(&mut opts.render);
-    }
-
-    let html = markdown_to_commonmark(text, &opts);
-    Ok(html)
-}
-
-#[pyfunction(name = "markdown_to_xml", signature=(text, extension_options=None, parse_options=None, render_options=None))]
-fn render_markdown_to_commonmark_xml(
-    text: &str,
-    extension_options: Option<PyExtensionOptions>,
-    parse_options: Option<PyParseOptions>,
-    render_options: Option<PyRenderOptions>,
-) -> PyResult<String> {
-    let mut opts = ComrakOptions::default();
-
-    // If user provided custom extension options, apply them.
-    if let Some(py_ext) = extension_options {
-        py_ext.update_extension_options(&mut opts.extension);
-    }
-
-    if let Some(py_parse) = parse_options {
-        py_parse.update_parse_options(&mut opts.parse);
-    }
-
-    if let Some(py_render) = render_options {
-        py_render.update_render_options(&mut opts.render);
-    }
-
-    let xml = markdown_to_commonmark_xml(text, &opts);
-    Ok(xml)
-}
-
-// Parse a Markdown string into a document structure and return as PyAstNode.
+/// Parse a Markdown string into a document structure and return as PyAstNode.
 #[pyfunction(name = "parse_document", signature=(text, extension_options=None, parse_options=None, render_options=None))]
 fn parse_markdown(
     py: Python,
@@ -134,6 +54,112 @@ fn parse_markdown(
     let document = parse_document(&arena, text, &opts);
     let py_node = PyAstNode::from_comrak_node(py, document, None);
     Ok(py_node)
+}
+
+/// Convert a Markdown string to CommonMark format.
+#[pyfunction(name = "markdown_to_commonmark", signature=(text, extension_options=None, parse_options=None, render_options=None))]
+fn render_markdown_to_commonmark(
+    text: &str,
+    extension_options: Option<PyExtensionOptions>,
+    parse_options: Option<PyParseOptions>,
+    render_options: Option<PyRenderOptions>,
+) -> PyResult<String> {
+    let mut opts = ComrakOptions::default();
+
+    // If user provided custom extension options, apply them.
+    if let Some(py_ext) = extension_options {
+        py_ext.update_extension_options(&mut opts.extension);
+    }
+
+    if let Some(py_parse) = parse_options {
+        py_parse.update_parse_options(&mut opts.parse);
+    }
+
+    if let Some(py_render) = render_options {
+        py_render.update_render_options(&mut opts.render);
+    }
+
+    let commonmark = markdown_to_commonmark(text, &opts);
+    Ok(commonmark)
+}
+
+/// Render a Markdown string to HTML, with optional Extension/Parse/Render overrides.
+#[pyfunction(name = "markdown_to_html", signature=(text, extension_options=None, parse_options=None, render_options=None))]
+fn render_markdown_to_html(
+    text: &str,
+    extension_options: Option<PyExtensionOptions>,
+    parse_options: Option<PyParseOptions>,
+    render_options: Option<PyRenderOptions>,
+) -> PyResult<String> {
+    let mut opts = ComrakOptions::default();
+
+    // If user provided custom extension options, apply them.
+    if let Some(py_ext) = extension_options {
+        py_ext.update_extension_options(&mut opts.extension);
+    }
+
+    if let Some(py_parse) = parse_options {
+        py_parse.update_parse_options(&mut opts.parse);
+    }
+
+    if let Some(py_render) = render_options {
+        py_render.update_render_options(&mut opts.render);
+    }
+
+    let html = markdown_to_html(text, &opts);
+    Ok(html)
+}
+
+#[pyfunction(name = "markdown_to_typst", signature=(text, extension_options=None, parse_options=None, render_options=None))]
+fn render_markdown_to_typst(
+    text: &str,
+    extension_options: Option<PyExtensionOptions>,
+    parse_options: Option<PyParseOptions>,
+    render_options: Option<PyRenderOptions>,
+) -> PyResult<String> {
+    let mut opts = ComrakOptions::default();
+
+    // If user provided custom extension options, apply them.
+    if let Some(py_ext) = extension_options {
+        py_ext.update_extension_options(&mut opts.extension);
+    }
+
+    if let Some(py_parse) = parse_options {
+        py_parse.update_parse_options(&mut opts.parse);
+    }
+
+    if let Some(py_render) = render_options {
+        py_render.update_render_options(&mut opts.render);
+    }
+
+    let typst = markdown_to_typst(text, &opts);
+    Ok(typst)
+}
+
+#[pyfunction(name = "markdown_to_xml", signature=(text, extension_options=None, parse_options=None, render_options=None))]
+fn render_markdown_to_xml(
+    text: &str,
+    extension_options: Option<PyExtensionOptions>,
+    parse_options: Option<PyParseOptions>,
+    render_options: Option<PyRenderOptions>,
+) -> PyResult<String> {
+    let mut opts = ComrakOptions::default();
+
+    // If user provided custom extension options, apply them.
+    if let Some(py_ext) = extension_options {
+        py_ext.update_extension_options(&mut opts.extension);
+    }
+
+    if let Some(py_parse) = parse_options {
+        py_parse.update_parse_options(&mut opts.parse);
+    }
+
+    if let Some(py_render) = render_options {
+        py_render.update_render_options(&mut opts.render);
+    }
+
+    let xml = markdown_to_commonmark_xml(text, &opts);
+    Ok(xml)
 }
 
 #[pyfunction(name = "format_commonmark", signature=(root, extension_options=None, parse_options=None, render_options=None))]
@@ -196,6 +222,36 @@ fn ast_format_html(
     Ok(output)
 }
 
+#[pyfunction(name = "format_typst", signature=(root, extension_options=None, parse_options=None, render_options=None))]
+fn ast_format_typst(
+    py: Python,
+    root: &PyAstNode,
+    extension_options: Option<PyExtensionOptions>,
+    parse_options: Option<PyParseOptions>,
+    render_options: Option<PyRenderOptions>,
+) -> PyResult<String> {
+    let mut opts = ComrakOptions::default();
+
+    // If user provided custom extension options, apply them.
+    if let Some(py_ext) = extension_options {
+        py_ext.update_extension_options(&mut opts.extension);
+    }
+
+    if let Some(py_parse) = parse_options {
+        py_parse.update_parse_options(&mut opts.parse);
+    }
+
+    if let Some(py_render) = render_options {
+        py_render.update_render_options(&mut opts.render);
+    }
+
+    let mut output = String::new();
+    let arena = Arena::new();
+    let root_node = root.to_comrak_node(py, &arena);
+    format_typst(root_node, &opts, &mut output).unwrap();
+    Ok(output)
+}
+
 #[pyfunction(name = "format_xml", signature=(root, extension_options=None, parse_options=None, render_options=None))]
 fn ast_format_xml(
     py: Python,
@@ -229,14 +285,15 @@ fn ast_format_xml(
 #[pymodule]
 fn comrak(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Expose the function
-    m.add_function(wrap_pyfunction!(render_markdown, m)?)?;
     m.add_function(wrap_pyfunction!(parse_markdown, m)?)?;
     m.add_function(wrap_pyfunction!(render_markdown_to_commonmark, m)?)?;
-    m.add_function(wrap_pyfunction!(render_markdown_to_commonmark_xml, m)?)?;
+    m.add_function(wrap_pyfunction!(render_markdown_to_html, m)?)?;
+    m.add_function(wrap_pyfunction!(render_markdown_to_typst, m)?)?;
+    m.add_function(wrap_pyfunction!(render_markdown_to_xml, m)?)?;
     m.add_function(wrap_pyfunction!(ast_format_commonmark, m)?)?;
     m.add_function(wrap_pyfunction!(ast_format_html, m)?)?;
+    m.add_function(wrap_pyfunction!(ast_format_typst, m)?)?;
     m.add_function(wrap_pyfunction!(ast_format_xml, m)?)?;
-
     // Expose the classes
     m.add_class::<PyExtensionOptions>()?;
     m.add_class::<PyParseOptions>()?;

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,7 +1,6 @@
 use pyo3::prelude::*;
 
-// Import the Comrak (Rust) types under `comrak_lib::`
-use comrak_lib::options::{
+use comrak::options::{
     Extension as ComrakExtensionOptions, Parse as ComrakParseOptions, Render as ComrakRenderOptions,
 };
 
@@ -34,6 +33,7 @@ pub struct PyExtensionOptions {
     pub cjk_friendly_emphasis: bool,
     pub subtext: bool,
     pub highlight: bool,
+    pub insert: bool,
     pub phoenix_heex: bool,
 }
 
@@ -65,6 +65,7 @@ impl PyExtensionOptions {
         opts.cjk_friendly_emphasis = self.cjk_friendly_emphasis;
         opts.subtext = self.subtext;
         opts.highlight = self.highlight;
+        opts.insert = self.insert;
         opts.phoenix_heex = self.phoenix_heex;
     }
 }
@@ -98,6 +99,7 @@ impl PyExtensionOptions {
         cjk_friendly_emphasis=None,
         subtext=None,
         highlight=None,
+        insert=None,
         phoenix_heex=None,
     ))]
     pub fn new(
@@ -126,6 +128,7 @@ impl PyExtensionOptions {
         cjk_friendly_emphasis: Option<bool>,
         subtext: Option<bool>,
         highlight: Option<bool>,
+        insert: Option<bool>,
         phoenix_heex: Option<bool>,
     ) -> Self {
         let defaults = ComrakExtensionOptions::default();
@@ -159,6 +162,7 @@ impl PyExtensionOptions {
             cjk_friendly_emphasis: cjk_friendly_emphasis.unwrap_or(defaults.cjk_friendly_emphasis),
             subtext: subtext.unwrap_or(defaults.subtext),
             highlight: highlight.unwrap_or(defaults.highlight),
+            insert: insert.unwrap_or(defaults.insert),
             phoenix_heex: phoenix_heex.unwrap_or(defaults.phoenix_heex),
         }
     }
@@ -259,6 +263,7 @@ pub struct PyRenderOptions {
     pub tasklist_classes: bool,
     pub ol_width: usize,
     pub experimental_minimize_commonmark: bool,
+    pub compact_html: bool,
 }
 
 impl PyRenderOptions {
@@ -272,9 +277,9 @@ impl PyRenderOptions {
         opts.escape = self.escape;
         // convert integer to ListStyleType
         opts.list_style = match self.list_style {
-            PyListStyleType::Dash => comrak_lib::options::ListStyleType::Dash,
-            PyListStyleType::Plus => comrak_lib::options::ListStyleType::Plus,
-            PyListStyleType::Star => comrak_lib::options::ListStyleType::Star,
+            PyListStyleType::Dash => comrak::options::ListStyleType::Dash,
+            PyListStyleType::Plus => comrak::options::ListStyleType::Plus,
+            PyListStyleType::Star => comrak::options::ListStyleType::Star,
         };
         opts.sourcepos = self.sourcepos;
         opts.escaped_char_spans = self.escaped_char_spans;
@@ -285,6 +290,7 @@ impl PyRenderOptions {
         opts.tasklist_classes = self.tasklist_classes;
         opts.ol_width = self.ol_width;
         opts.experimental_minimize_commonmark = self.experimental_minimize_commonmark;
+        opts.compact_html = self.compact_html;
     }
 }
 
@@ -308,6 +314,7 @@ impl PyRenderOptions {
         tasklist_classes=None,
         ol_width=None,
         experimental_minimize_commonmark=None,
+        compact_html=None,
     ))]
     pub fn new(
         hardbreaks: Option<bool>,
@@ -326,6 +333,7 @@ impl PyRenderOptions {
         tasklist_classes: Option<bool>,
         ol_width: Option<usize>,
         experimental_minimize_commonmark: Option<bool>,
+        compact_html: Option<bool>,
     ) -> Self {
         let defaults = ComrakRenderOptions::default();
         Self {
@@ -336,9 +344,9 @@ impl PyRenderOptions {
             r#unsafe: unsafe_.unwrap_or(defaults.r#unsafe),
             escape: escape.unwrap_or(defaults.escape),
             list_style: list_style.unwrap_or(match defaults.list_style {
-                comrak_lib::options::ListStyleType::Dash => PyListStyleType::Dash,
-                comrak_lib::options::ListStyleType::Plus => PyListStyleType::Plus,
-                comrak_lib::options::ListStyleType::Star => PyListStyleType::Star,
+                comrak::options::ListStyleType::Dash => PyListStyleType::Dash,
+                comrak::options::ListStyleType::Plus => PyListStyleType::Plus,
+                comrak::options::ListStyleType::Star => PyListStyleType::Star,
             }),
             sourcepos: sourcepos.unwrap_or(defaults.sourcepos),
             escaped_char_spans: escaped_char_spans.unwrap_or(defaults.escaped_char_spans),
@@ -350,6 +358,7 @@ impl PyRenderOptions {
             ol_width: ol_width.unwrap_or(defaults.ol_width),
             experimental_minimize_commonmark: experimental_minimize_commonmark
                 .unwrap_or(defaults.experimental_minimize_commonmark),
+            compact_html: compact_html.unwrap_or(defaults.compact_html),
         }
     }
 }


### PR DESCRIPTION
This pull request introduces several improvements and new features to the Python bindings for the Comrak Markdown parser. The most notable changes include support for new Markdown extensions, expanded rendering and formatting options, and updates to the project metadata and dependencies.

**New Markdown extensions and options:**

* Added support for the "insert" extension, including the new `Insert` AST node and the corresponding `insert` option in `ExtensionOptions`. [[1]](diffhunk://#diff-99fc377d3285afca28524e04fc8573099c38fbf534d3d230f28ddc4f9f06dbc8R303-R305) [[2]](diffhunk://#diff-99fc377d3285afca28524e04fc8573099c38fbf534d3d230f28ddc4f9f06dbc8R409) [[3]](diffhunk://#diff-99fc377d3285afca28524e04fc8573099c38fbf534d3d230f28ddc4f9f06dbc8R438) [[4]](diffhunk://#diff-efdec6354480057065a2ae9df10063cfed83119dd1a10cac520940c5816167bbR1226-R1237)

**Rendering and formatting enhancements:**

* Introduced new rendering functions: `markdown_to_typst` and `format_typst`, allowing conversion of Markdown to Typst format and formatting AST nodes back to Typst. [[1]](diffhunk://#diff-99fc377d3285afca28524e04fc8573099c38fbf534d3d230f28ddc4f9f06dbc8R499-R520) [[2]](diffhunk://#diff-99fc377d3285afca28524e04fc8573099c38fbf534d3d230f28ddc4f9f06dbc8L513-R544) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L61-R112) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L118-R165)
* Added `compact_html` option to `RenderOptions` for more customizable HTML output. [[1]](diffhunk://#diff-99fc377d3285afca28524e04fc8573099c38fbf534d3d230f28ddc4f9f06dbc8R480) [[2]](diffhunk://#diff-99fc377d3285afca28524e04fc8573099c38fbf534d3d230f28ddc4f9f06dbc8R499-R520)
* Improved AST formatting with new `format_commonmark` and `format_typst` functions, and updated documentation to reflect these changes. [[1]](diffhunk://#diff-99fc377d3285afca28524e04fc8573099c38fbf534d3d230f28ddc4f9f06dbc8L513-R544) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L73-R139) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L118-R165)

**Project metadata and dependency updates:**

* Updated the crate name to `comrak-ext` and switched dependency from `comrak_lib` to `comrak` version 0.51.0 in `Cargo.toml`.
* Changed import statements in Rust code to match new dependency naming.

**Documentation improvements:**

* Reorganized and expanded the `README.md` to clarify parsing, rendering, and formatting APIs, including detailed usage examples for new and existing functions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L30-R66) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L61-R112) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L73-R139) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L118-R165)

These changes collectively make the library more versatile and easier to use, with improved support for Markdown extensions and richer output formats.