### PR TITLE
feat: Update Comrak to v0.52.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -34,15 +34,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -53,7 +53,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -64,7 +64,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -111,9 +111,9 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "bon"
-version = "3.9.0"
+version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d13a61f2963b88eef9c1be03df65d42f6996dfeac1054870d950fcf66686f83"
+checksum = "f47dbe92550676ee653353c310dfb9cf6ba17ee70396e1f7cf0a2020ad49b2fe"
 dependencies = [
  "bon-macros",
  "rustversion",
@@ -121,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "bon-macros"
-version = "3.9.0"
+version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d314cc62af2b6b0c65780555abb4d02a03dd3b799cd42419044f0c38d99738c0"
+checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
  "darling",
  "ident_case",
@@ -145,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -161,9 +161,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -171,9 +171,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -184,9 +184,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -196,21 +196,21 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "comrak"
-version = "0.51.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f07383e7799d964bf7ffa6fc4457d177c54a44614661c7458bb0bd91b108e32"
+checksum = "aac0b255932a9cd52fbfd664b67957f9f2e095ae4711cb0e41b4e291edef94c2"
 dependencies = [
  "bon",
  "caseless",
@@ -318,7 +318,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -334,9 +334,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
 
 [[package]]
 name = "find-msvc-tools"
@@ -392,9 +392,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -417,9 +417,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jetscii"
@@ -429,9 +429,9 @@ checksum = "47f142fe24a9c9944451e8349de0a56af5f3e7226dc46f3ed4d4ecc0b85af75e"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "linked-hash-map"
@@ -472,15 +472,15 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -697,9 +697,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
@@ -711,7 +711,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -785,9 +785,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "siphasher"
@@ -848,12 +848,12 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "terminal_size"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -909,9 +909,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -971,7 +971,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -982,86 +982,12 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "xdg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [dependencies]
-comrak = { version = "0.51.0", features = ["shortcodes", "phoenix_heex"] }
+comrak = { version = "0.52.0", features = ["shortcodes", "phoenix_heex"] }
 pyo3 = "0.27.2"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -94,21 +94,6 @@ markdown_to_html("foo :smile:", extension_options)
 # '<p>foo 😄</p>\n'
 ```
 
-#### `markdown_to_typst`
-
-Render Markdown to Typst:
-
-```python
-from comrak import ExtensionOptions, markdown_to_typst
-extension_options = ExtensionOptions()
-markdown_to_typst("foo :smile:", extension_options)
-# 'Ligature : A merged glyph.\n'
-
-extension_options.description_lists = True
-markdown_to_typst("foo :smile:", extension_options)
-# '#terms(\n  terms.item([Ligature], [A merged glyph.]),\n)\n'
-```
-
 #### `markdown_to_xml`
 
 Render Markdown to XML:
@@ -147,19 +132,6 @@ p = parse_document("> Greentext blockquote requires a space after `>`")
 
 format_html(p)
 # '<blockquote>\n<p>Greentext blockquote requires a space after <code>&gt;</code></p>\n</blockquote>\n'
-```
-
-#### `format_typst`
-
-Format an AST back to Typst:
-
-```python
-from comrak import parse_document, format_typst
-
-p = parse_document("> Greentext blockquote requires a space after `>`")
-
-format_typst(p)
-# '#quote(block: true)[Greentext blockquote requires a space after #raw(">")]\n'
 ```
 
 #### `format_xml`

--- a/comrak.pyi
+++ b/comrak.pyi
@@ -169,6 +169,12 @@ class NodeAlert:
         fence_offset: int,
     ) -> None: ...
 
+class NodeBlockDirective:
+    fence_length: int
+    fence_offset: int
+    info: str
+    def __init__(self, fence_length: int, fence_offset: int, info: str) -> None: ...
+
 class HeexNodeDirective(HeexNode[None]):
     def __init__(self) -> None: ...
 
@@ -357,6 +363,10 @@ class Alert(NodeValue[NodeAlert]):
 class Subtext(NodeValue[None]):
     def __init__(self) -> None: ...
 
+class BlockDirective(NodeValue[NodeBlockDirective]):
+    value: NodeBlockDirective
+    def __init__(self, value: NodeBlockDirective) -> None: ...
+
 class LineColumn:
     line: int
     column: int
@@ -387,7 +397,8 @@ class ExtensionOptions:
     autolink: bool
     tasklist: bool
     superscript: bool
-    header_ids: Optional[str]
+    header_id_prefix: Optional[str]
+    header_id_prefix_in_href: bool
     footnotes: bool
     inline_footnotes: bool
     description_lists: bool
@@ -408,6 +419,7 @@ class ExtensionOptions:
     highlight: bool
     insert: bool
     phoenix_heex: bool
+    block_directive: bool
     def __init__(
         self,
         strikethrough: bool = False,
@@ -416,7 +428,8 @@ class ExtensionOptions:
         autolink: bool = False,
         tasklist: bool = False,
         superscript: bool = False,
-        header_ids: Optional[str] = None,
+        header_id_prefix: Optional[str] = None,
+        header_id_prefix_in_href: bool = False,
         footnotes: bool = False,
         inline_footnotes: bool = False,
         description_lists: bool = False,
@@ -437,6 +450,7 @@ class ExtensionOptions:
         highlight: bool = False,
         insert: bool = False,
         phoenix_heex: bool = False,
+        block_directive: bool = False,
     ) -> None: ...
 
 class ParseOptions:
@@ -448,6 +462,7 @@ class ParseOptions:
     ignore_setext: bool
     leave_footnote_definitions: bool
     escaped_char_spans: bool
+    sourcepos_chars: bool
     def __init__(
         self,
         smart: bool = False,
@@ -458,6 +473,7 @@ class ParseOptions:
         ignore_setext: bool = False,
         leave_footnote_definitions: bool = False,
         escaped_char_spans: bool = False,
+        sourcepos_chars: bool = False,
     ) -> None: ...
 
 class RenderOptions:
@@ -517,12 +533,6 @@ def markdown_to_html(
     parse_options: Optional[ParseOptions] = None,
     render_options: Optional[RenderOptions] = None,
 ) -> str: ...
-def markdown_to_typst(
-    text: str,
-    extension_options: Optional[ExtensionOptions] = None,
-    parse_options: Optional[ParseOptions] = None,
-    render_options: Optional[RenderOptions] = None,
-) -> str: ...
 def markdown_to_xml(
     text: str,
     extension_options: Optional[ExtensionOptions] = None,
@@ -536,12 +546,6 @@ def format_commonmark(
     render_options: Optional[RenderOptions] = None,
 ) -> str: ...
 def format_html(
-    node: AstNode,
-    extension_options: Optional[ExtensionOptions] = None,
-    parse_options: Optional[ParseOptions] = None,
-    render_options: Optional[RenderOptions] = None,
-) -> str: ...
-def format_typst(
     node: AstNode,
     extension_options: Optional[ExtensionOptions] = None,
     parse_options: Optional[ParseOptions] = None,

--- a/src/astnode.rs
+++ b/src/astnode.rs
@@ -627,6 +627,36 @@ impl PyNodeAlert {
     }
 }
 
+#[pyclass(name = "NodeBlockDirective", get_all, set_all, eq)]
+#[derive(Clone, PartialEq, Eq)]
+pub struct PyNodeBlockDirective {
+    pub fence_length: usize,
+    pub fence_offset: usize,
+    pub info: String,
+}
+
+impl From<&NodeBlockDirective> for PyNodeBlockDirective {
+    fn from(bd: &NodeBlockDirective) -> Self {
+        Self {
+            fence_length: bd.fence_length,
+            fence_offset: bd.fence_offset,
+            info: bd.info.clone(),
+        }
+    }
+}
+
+#[pymethods]
+impl PyNodeBlockDirective {
+    #[new]
+    pub fn new(fence_length: usize, fence_offset: usize, info: String) -> Self {
+        Self {
+            fence_length,
+            fence_offset,
+            info,
+        }
+    }
+}
+
 #[pyclass(name = "HeexNode", subclass, eq)]
 #[derive(Clone, PartialEq, Eq)]
 pub struct PyHeexNode {}
@@ -1434,6 +1464,20 @@ impl PySubtext {
     }
 }
 
+#[pyclass(name = "BlockDirective", extends=PyNodeValue, get_all, set_all, eq)]
+#[derive(PartialEq, Eq)]
+pub struct PyBlockDirective {
+    pub value: PyNodeBlockDirective,
+}
+
+#[pymethods]
+impl PyBlockDirective {
+    #[new]
+    pub fn new(value: PyNodeBlockDirective) -> (Self, PyNodeValue) {
+        (Self { value }, PyNodeValue::new())
+    }
+}
+
 #[pyclass(name = "AstNode", get_all, set_all)]
 pub struct PyAstNode {
     pub node_value: Py<PyAny>,
@@ -1786,6 +1830,14 @@ fn create_py_node_value(py: Python, value: &comrak::nodes::NodeValue) -> Py<PyAn
         comrak::nodes::NodeValue::Subtext => Py::new(
             py,
             PyClassInitializer::from(PyNodeValue {}).add_subclass(PySubtext {}),
+        )
+        .unwrap()
+        .into(),
+        comrak::nodes::NodeValue::BlockDirective(d) => Py::new(
+            py,
+            PyClassInitializer::from(PyNodeValue {}).add_subclass(PyBlockDirective {
+                value: PyNodeBlockDirective::from(d.as_ref()),
+            }),
         )
         .unwrap()
         .into(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,8 @@
 use pyo3::prelude::*;
 
 use ::comrak::{
-    format_commonmark, format_html, format_typst, format_xml, markdown_to_commonmark,
-    markdown_to_commonmark_xml, markdown_to_html, markdown_to_typst, parse_document, Arena,
-    Options as ComrakOptions,
+    format_commonmark, format_html, format_xml, markdown_to_commonmark, markdown_to_commonmark_xml,
+    markdown_to_html, parse_document, Arena, Options as ComrakOptions,
 };
 
 // Import the Python option classes we defined
@@ -11,19 +10,19 @@ mod options;
 use options::{PyExtensionOptions, PyListStyleType, PyParseOptions, PyRenderOptions};
 mod astnode;
 use astnode::{
-    PyAlert, PyAlertType, PyAstNode, PyBlockQuote, PyCode, PyCodeBlock, PyDescriptionDetails,
-    PyDescriptionItem, PyDescriptionList, PyDescriptionTerm, PyDocument, PyEmph, PyEscaped,
-    PyEscapedTag, PyFootnoteDefinition, PyFootnoteReference, PyFrontMatter, PyHeading, PyHeexBlock,
-    PyHeexInline, PyHeexNode, PyHeexNodeComment, PyHeexNodeDirective, PyHeexNodeExpression,
-    PyHeexNodeMultilineComment, PyHeexNodeTag, PyHighlight, PyHtmlBlock, PyHtmlInline, PyImage,
-    PyItem, PyLineBreak, PyLineColumn, PyLink, PyList, PyListDelimType, PyListType, PyMath,
-    PyMultilineBlockQuote, PyNodeAlert, PyNodeCode, PyNodeCodeBlock, PyNodeDescriptionItem,
-    PyNodeFootnoteDefinition, PyNodeFootnoteReference, PyNodeHeading, PyNodeHeexBlock,
-    PyNodeHtmlBlock, PyNodeLink, PyNodeList, PyNodeMath, PyNodeMultilineBlockQuote,
-    PyNodeShortCode, PyNodeTable, PyNodeTaskItem, PyNodeValue, PyNodeWikiLink, PyParagraph, PyRaw,
-    PyShortCode, PySoftBreak, PySourcepos, PySpoileredText, PyStrikethrough, PyStrong, PySubscript,
-    PySubtext, PySuperscript, PyTable, PyTableAlignment, PyTableCell, PyTableRow, PyTaskItem,
-    PyText, PyThematicBreak, PyUnderline, PyWikiLink,
+    PyAlert, PyAlertType, PyAstNode, PyBlockDirective, PyBlockQuote, PyCode, PyCodeBlock,
+    PyDescriptionDetails, PyDescriptionItem, PyDescriptionList, PyDescriptionTerm, PyDocument,
+    PyEmph, PyEscaped, PyEscapedTag, PyFootnoteDefinition, PyFootnoteReference, PyFrontMatter,
+    PyHeading, PyHeexBlock, PyHeexInline, PyHeexNode, PyHeexNodeComment, PyHeexNodeDirective,
+    PyHeexNodeExpression, PyHeexNodeMultilineComment, PyHeexNodeTag, PyHighlight, PyHtmlBlock,
+    PyHtmlInline, PyImage, PyItem, PyLineBreak, PyLineColumn, PyLink, PyList, PyListDelimType,
+    PyListType, PyMath, PyMultilineBlockQuote, PyNodeAlert, PyNodeBlockDirective, PyNodeCode,
+    PyNodeCodeBlock, PyNodeDescriptionItem, PyNodeFootnoteDefinition, PyNodeFootnoteReference,
+    PyNodeHeading, PyNodeHeexBlock, PyNodeHtmlBlock, PyNodeLink, PyNodeList, PyNodeMath,
+    PyNodeMultilineBlockQuote, PyNodeShortCode, PyNodeTable, PyNodeTaskItem, PyNodeValue,
+    PyNodeWikiLink, PyParagraph, PyRaw, PyShortCode, PySoftBreak, PySourcepos, PySpoileredText,
+    PyStrikethrough, PyStrong, PySubscript, PySubtext, PySuperscript, PyTable, PyTableAlignment,
+    PyTableCell, PyTableRow, PyTaskItem, PyText, PyThematicBreak, PyUnderline, PyWikiLink,
 };
 
 /// Parse a Markdown string into a document structure and return as PyAstNode.
@@ -108,32 +107,6 @@ fn render_markdown_to_html(
 
     let html = markdown_to_html(text, &opts);
     Ok(html)
-}
-
-#[pyfunction(name = "markdown_to_typst", signature=(text, extension_options=None, parse_options=None, render_options=None))]
-fn render_markdown_to_typst(
-    text: &str,
-    extension_options: Option<PyExtensionOptions>,
-    parse_options: Option<PyParseOptions>,
-    render_options: Option<PyRenderOptions>,
-) -> PyResult<String> {
-    let mut opts = ComrakOptions::default();
-
-    // If user provided custom extension options, apply them.
-    if let Some(py_ext) = extension_options {
-        py_ext.update_extension_options(&mut opts.extension);
-    }
-
-    if let Some(py_parse) = parse_options {
-        py_parse.update_parse_options(&mut opts.parse);
-    }
-
-    if let Some(py_render) = render_options {
-        py_render.update_render_options(&mut opts.render);
-    }
-
-    let typst = markdown_to_typst(text, &opts);
-    Ok(typst)
 }
 
 #[pyfunction(name = "markdown_to_xml", signature=(text, extension_options=None, parse_options=None, render_options=None))]
@@ -222,36 +195,6 @@ fn ast_format_html(
     Ok(output)
 }
 
-#[pyfunction(name = "format_typst", signature=(root, extension_options=None, parse_options=None, render_options=None))]
-fn ast_format_typst(
-    py: Python,
-    root: &PyAstNode,
-    extension_options: Option<PyExtensionOptions>,
-    parse_options: Option<PyParseOptions>,
-    render_options: Option<PyRenderOptions>,
-) -> PyResult<String> {
-    let mut opts = ComrakOptions::default();
-
-    // If user provided custom extension options, apply them.
-    if let Some(py_ext) = extension_options {
-        py_ext.update_extension_options(&mut opts.extension);
-    }
-
-    if let Some(py_parse) = parse_options {
-        py_parse.update_parse_options(&mut opts.parse);
-    }
-
-    if let Some(py_render) = render_options {
-        py_render.update_render_options(&mut opts.render);
-    }
-
-    let mut output = String::new();
-    let arena = Arena::new();
-    let root_node = root.to_comrak_node(py, &arena);
-    format_typst(root_node, &opts, &mut output).unwrap();
-    Ok(output)
-}
-
 #[pyfunction(name = "format_xml", signature=(root, extension_options=None, parse_options=None, render_options=None))]
 fn ast_format_xml(
     py: Python,
@@ -288,11 +231,9 @@ fn comrak(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(parse_markdown, m)?)?;
     m.add_function(wrap_pyfunction!(render_markdown_to_commonmark, m)?)?;
     m.add_function(wrap_pyfunction!(render_markdown_to_html, m)?)?;
-    m.add_function(wrap_pyfunction!(render_markdown_to_typst, m)?)?;
     m.add_function(wrap_pyfunction!(render_markdown_to_xml, m)?)?;
     m.add_function(wrap_pyfunction!(ast_format_commonmark, m)?)?;
     m.add_function(wrap_pyfunction!(ast_format_html, m)?)?;
-    m.add_function(wrap_pyfunction!(ast_format_typst, m)?)?;
     m.add_function(wrap_pyfunction!(ast_format_xml, m)?)?;
     // Expose the classes
     m.add_class::<PyExtensionOptions>()?;
@@ -344,6 +285,7 @@ fn comrak(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PySpoileredText>()?;
     m.add_class::<PyEscapedTag>()?;
     m.add_class::<PyAlert>()?;
+    m.add_class::<PyBlockDirective>()?;
     m.add_class::<PyNodeCode>()?;
     m.add_class::<PyNodeHtmlBlock>()?;
     m.add_class::<PyListDelimType>()?;
@@ -363,6 +305,7 @@ fn comrak(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyNodeMultilineBlockQuote>()?;
     m.add_class::<PyAlertType>()?;
     m.add_class::<PyNodeAlert>()?;
+    m.add_class::<PyNodeBlockDirective>()?;
     m.add_class::<PyAstNode>()?;
     m.add_class::<PyHeexNode>()?;
     m.add_class::<PyHeexNodeTag>()?;

--- a/src/options.rs
+++ b/src/options.rs
@@ -14,7 +14,8 @@ pub struct PyExtensionOptions {
     pub autolink: bool,
     pub tasklist: bool,
     pub superscript: bool,
-    pub header_ids: Option<String>,
+    pub header_id_prefix: Option<String>,
+    pub header_id_prefix_in_href: bool,
     pub footnotes: bool,
     pub inline_footnotes: bool,
     pub description_lists: bool,
@@ -35,6 +36,7 @@ pub struct PyExtensionOptions {
     pub highlight: bool,
     pub insert: bool,
     pub phoenix_heex: bool,
+    pub block_directive: bool,
 }
 
 impl PyExtensionOptions {
@@ -46,7 +48,8 @@ impl PyExtensionOptions {
         opts.autolink = self.autolink;
         opts.tasklist = self.tasklist;
         opts.superscript = self.superscript;
-        opts.header_ids = self.header_ids.clone();
+        opts.header_id_prefix = self.header_id_prefix.clone();
+        opts.header_id_prefix_in_href = self.header_id_prefix_in_href;
         opts.footnotes = self.footnotes;
         opts.inline_footnotes = self.inline_footnotes;
         opts.description_lists = self.description_lists;
@@ -67,6 +70,7 @@ impl PyExtensionOptions {
         opts.highlight = self.highlight;
         opts.insert = self.insert;
         opts.phoenix_heex = self.phoenix_heex;
+        opts.block_directive = self.block_directive;
     }
 }
 
@@ -80,7 +84,8 @@ impl PyExtensionOptions {
         autolink=None,
         tasklist=None,
         superscript=None,
-        header_ids=None,
+        header_id_prefix=None,
+        header_id_prefix_in_href=None,
         footnotes=None,
         inline_footnotes=None,
         description_lists=None,
@@ -101,6 +106,7 @@ impl PyExtensionOptions {
         highlight=None,
         insert=None,
         phoenix_heex=None,
+        block_directive=None,
     ))]
     pub fn new(
         strikethrough: Option<bool>,
@@ -109,7 +115,8 @@ impl PyExtensionOptions {
         autolink: Option<bool>,
         tasklist: Option<bool>,
         superscript: Option<bool>,
-        header_ids: Option<String>,
+        header_id_prefix: Option<String>,
+        header_id_prefix_in_href: Option<bool>,
         footnotes: Option<bool>,
         inline_footnotes: Option<bool>,
         description_lists: Option<bool>,
@@ -130,6 +137,7 @@ impl PyExtensionOptions {
         highlight: Option<bool>,
         insert: Option<bool>,
         phoenix_heex: Option<bool>,
+        block_directive: Option<bool>,
     ) -> Self {
         let defaults = ComrakExtensionOptions::default();
         Self {
@@ -139,7 +147,9 @@ impl PyExtensionOptions {
             autolink: autolink.unwrap_or(defaults.autolink),
             tasklist: tasklist.unwrap_or(defaults.tasklist),
             superscript: superscript.unwrap_or(defaults.superscript),
-            header_ids: header_ids.or(defaults.header_ids.clone()),
+            header_id_prefix: header_id_prefix.or(defaults.header_id_prefix.clone()),
+            header_id_prefix_in_href: header_id_prefix_in_href
+                .unwrap_or(defaults.header_id_prefix_in_href),
             footnotes: footnotes.unwrap_or(defaults.footnotes),
             inline_footnotes: inline_footnotes.unwrap_or(defaults.inline_footnotes),
             description_lists: description_lists.unwrap_or(defaults.description_lists),
@@ -164,6 +174,7 @@ impl PyExtensionOptions {
             highlight: highlight.unwrap_or(defaults.highlight),
             insert: insert.unwrap_or(defaults.insert),
             phoenix_heex: phoenix_heex.unwrap_or(defaults.phoenix_heex),
+            block_directive: block_directive.unwrap_or(defaults.block_directive),
         }
     }
 }
@@ -180,6 +191,7 @@ pub struct PyParseOptions {
     pub ignore_setext: bool,
     pub leave_footnote_definitions: bool,
     pub escaped_char_spans: bool,
+    pub sourcepos_chars: bool,
 }
 
 impl PyParseOptions {
@@ -193,6 +205,7 @@ impl PyParseOptions {
         opts.ignore_setext = self.ignore_setext;
         opts.leave_footnote_definitions = self.leave_footnote_definitions;
         opts.escaped_char_spans = self.escaped_char_spans;
+        opts.sourcepos_chars = self.sourcepos_chars;
     }
 }
 
@@ -207,7 +220,8 @@ impl PyParseOptions {
         relaxed_autolinks=None,
         ignore_setext=None,
         leave_footnote_definitions=None,
-        escaped_char_spans=None
+        escaped_char_spans=None,
+        sourcepos_chars=None,
     ))]
     pub fn new(
         smart: Option<bool>,
@@ -218,6 +232,7 @@ impl PyParseOptions {
         ignore_setext: Option<bool>,
         leave_footnote_definitions: Option<bool>,
         escaped_char_spans: Option<bool>,
+        sourcepos_chars: Option<bool>,
     ) -> Self {
         let defaults = ComrakParseOptions::default();
         Self {
@@ -231,6 +246,7 @@ impl PyParseOptions {
             leave_footnote_definitions: leave_footnote_definitions
                 .unwrap_or(defaults.leave_footnote_definitions),
             escaped_char_spans: escaped_char_spans.unwrap_or(defaults.escaped_char_spans),
+            sourcepos_chars: sourcepos_chars.unwrap_or(defaults.sourcepos_chars),
         }
     }
 }


### PR DESCRIPTION
This pull request removes Typst-related functionality from the Python bindings and adds support for block directives in both the AST and extension options. It also updates the comrak dependency and introduces several new fields and classes to improve Markdown parsing and extension configuration.

**Removal of Typst support:**

- Removed all functions and type definitions related to Typst rendering and formatting from the Python API, including `markdown_to_typst` and `format_typst`. Corresponding documentation and type stubs were also deleted. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L97-L111) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L152-L164) [[3]](diffhunk://#diff-99fc377d3285afca28524e04fc8573099c38fbf534d3d230f28ddc4f9f06dbc8L520-L525) [[4]](diffhunk://#diff-99fc377d3285afca28524e04fc8573099c38fbf534d3d230f28ddc4f9f06dbc8L544-L549) [[5]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L4-R25) [[6]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L113-L138) [[7]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L225-L254) [[8]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L291-L295)

**Block directive support:**

- Added new AST node classes `NodeBlockDirective` and `BlockDirective` to represent block directives, with Python bindings and integration into the AST conversion logic. [[1]](diffhunk://#diff-99fc377d3285afca28524e04fc8573099c38fbf534d3d230f28ddc4f9f06dbc8R172-R177) [[2]](diffhunk://#diff-99fc377d3285afca28524e04fc8573099c38fbf534d3d230f28ddc4f9f06dbc8R366-R369) [[3]](diffhunk://#diff-efdec6354480057065a2ae9df10063cfed83119dd1a10cac520940c5816167bbR630-R659) [[4]](diffhunk://#diff-efdec6354480057065a2ae9df10063cfed83119dd1a10cac520940c5816167bbR1467-R1480) [[5]](diffhunk://#diff-efdec6354480057065a2ae9df10063cfed83119dd1a10cac520940c5816167bbR1836-R1843) [[6]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L4-R25) [[7]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R288) [[8]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R308)
- Added a `block_directive` boolean flag to the `ExtensionOptions` class and its Rust counterpart, allowing users to enable or disable block directive parsing. [[1]](diffhunk://#diff-99fc377d3285afca28524e04fc8573099c38fbf534d3d230f28ddc4f9f06dbc8R422) [[2]](diffhunk://#diff-99fc377d3285afca28524e04fc8573099c38fbf534d3d230f28ddc4f9f06dbc8R453) [[3]](diffhunk://#diff-a54b690591939c29d3e6915248aa5ff5371e4142f28ae1ae0ea3e45831f2312fR39) [[4]](diffhunk://#diff-a54b690591939c29d3e6915248aa5ff5371e4142f28ae1ae0ea3e45831f2312fR73) [[5]](diffhunk://#diff-a54b690591939c29d3e6915248aa5ff5371e4142f28ae1ae0ea3e45831f2312fR109) [[6]](diffhunk://#diff-a54b690591939c29d3e6915248aa5ff5371e4142f28ae1ae0ea3e45831f2312fR140)

**Extension options improvements:**

- Replaced the `header_ids` field with `header_id_prefix` and added a new boolean `header_id_prefix_in_href` to `ExtensionOptions` and Rust options, for more flexible header ID configuration. [[1]](diffhunk://#diff-99fc377d3285afca28524e04fc8573099c38fbf534d3d230f28ddc4f9f06dbc8L390-R401) [[2]](diffhunk://#diff-99fc377d3285afca28524e04fc8573099c38fbf534d3d230f28ddc4f9f06dbc8L419-R432) [[3]](diffhunk://#diff-a54b690591939c29d3e6915248aa5ff5371e4142f28ae1ae0ea3e45831f2312fL17-R18) [[4]](diffhunk://#diff-a54b690591939c29d3e6915248aa5ff5371e4142f28ae1ae0ea3e45831f2312fL49-R52) [[5]](diffhunk://#diff-a54b690591939c29d3e6915248aa5ff5371e4142f28ae1ae0ea3e45831f2312fL83-R88) [[6]](diffhunk://#diff-a54b690591939c29d3e6915248aa5ff5371e4142f28ae1ae0ea3e45831f2312fL112-R119)

**Dependency updates:**

- Updated the `comrak` dependency from version 0.51.0 to 0.52.0 in `Cargo.toml`.

**Parsing option enhancements:**

- Added a new `sourcepos_chars` boolean field to `ParseOptions` for character-based source position tracking. [[1]](diffhunk://#diff-99fc377d3285afca28524e04fc8573099c38fbf534d3d230f28ddc4f9f06dbc8R465) [[2]](diffhunk://#diff-99fc377d3285afca28524e04fc8573099c38fbf534d3d230f28ddc4f9f06dbc8R476)