### PR TITLE
feat: Update Comrak to v0.53.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,9 +202,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "comrak"
-version = "0.52.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aac0b255932a9cd52fbfd664b67957f9f2e095ae4711cb0e41b4e291edef94c2"
+checksum = "9795cb30f4deefbf33488819707e0f9630535dd56208ec273c1b3f150196377a"
 dependencies = [
  "bon",
  "caseless",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [dependencies]
-comrak = { version = "0.52.0", features = ["shortcodes", "phoenix_heex"] }
+comrak = { version = "0.53.0", features = ["shortcodes", "phoenix_heex"] }
 pyo3 = { version = "0.29.0" }
 
 [lib]


### PR DESCRIPTION
This PR updates the `comrak` Rust crate to [version 0.53.0](https://github.com/kivikakk/comrak/releases/tag/v0.53.0).